### PR TITLE
Feat: 도서 리뷰 CRUD 기능 및 이미지 관리, 평점 연동 구현

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
             <scope>test</scope>
         </dependency>
 
-        <!--        Elastic Search-->
+        <!--        Elasticsearch-->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-elasticsearch</artifactId>
@@ -115,6 +115,11 @@
             <groupId>io.minio</groupId>
             <artifactId>minio</artifactId>
             <version>8.6.0</version>
+        </dependency>
+        <!--    FeignClient-->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-openfeign</artifactId>
         </dependency>
     </dependencies>
 

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/Book2OnAndOnBookServiceApplication.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/Book2OnAndOnBookServiceApplication.java
@@ -3,11 +3,13 @@ package org.nhnacademy.book2onandonbookservice;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableDiscoveryClient
 @EnableScheduling
+@EnableFeignClients
 public class Book2OnAndOnBookServiceApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/client/OrderServiceClient.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/client/OrderServiceClient.java
@@ -1,0 +1,13 @@
+package org.nhnacademy.book2onandonbookservice.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(name = "ORDER-SERVICE")
+public interface OrderServiceClient {
+
+    @GetMapping("/api/orders/check-purchase/{bookId}")
+    boolean hasPurchased(@RequestHeader("X-User-Id") Long userId, @PathVariable Long bookId);
+}

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/controller/BookController.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/controller/BookController.java
@@ -48,7 +48,7 @@ public class BookController {
     public ResponseEntity<List<CategoryDto>> getCategory() {
         log.info("전체 카테고리 목록 조회 요청");
         List<CategoryDto> categories = bookService.getCategories();
-        log.info("카테고리: {}", categories);
+        log.info("조회된 카테고리 개수: {}", categories.size());
         return ResponseEntity.ok(categories);
     }
 

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/controller/ReviewController.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/controller/ReviewController.java
@@ -1,0 +1,68 @@
+package org.nhnacademy.book2onandonbookservice.controller;
+
+
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.nhnacademy.book2onandonbookservice.dto.review.ReviewCreateRequest;
+import org.nhnacademy.book2onandonbookservice.dto.review.ReviewDto;
+import org.nhnacademy.book2onandonbookservice.dto.review.ReviewUpdateRequest;
+import org.nhnacademy.book2onandonbookservice.service.review.ReviewService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/books")
+public class ReviewController {
+
+    private final ReviewService reviewService;
+
+    //리뷰생성
+    @PostMapping(value = "/{bookId}/reviews", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<Long> createReview(@PathVariable Long bookId,
+                                             @RequestPart(value = "request") @Valid ReviewCreateRequest request,
+                                             @RequestPart(value = "images", required = false) List<MultipartFile> images) {
+        Long reviewId = reviewService.createReview(bookId, request, images);
+        return ResponseEntity.status(HttpStatus.CREATED).body(reviewId);
+    }
+
+    //특정 도서에 대한 리뷰목록
+    @GetMapping(value = "/{bookId}/reviews")
+    public ResponseEntity<Page<ReviewDto>> getReviewList(@PathVariable Long bookId,
+                                                         @PageableDefault(page = 0, size = 10, sort = "createdAt", direction = Direction.DESC) Pageable pageable) {
+        Page<ReviewDto> reviewPage = reviewService.getReviewListByBookId(bookId, pageable);
+        return ResponseEntity.ok(reviewPage);
+    }
+
+    //리뷰수정
+    @PutMapping(value = "/reviews/{reviewId}")
+    public ResponseEntity<Void> updateReview(@PathVariable Long reviewId,
+                                             @RequestPart(value = "request") @Valid ReviewUpdateRequest request,
+                                             @RequestPart(value = "images", required = false) List<MultipartFile> newImages) {
+        reviewService.updateReview(reviewId, request, newImages);
+        return ResponseEntity.ok().build();
+    }
+
+    //리뷰삭제
+    @DeleteMapping("/reviews/{reviewId}")
+    public ResponseEntity<Void> deleteReview(@PathVariable Long reviewId) {
+        reviewService.deleteReview(reviewId);
+        return ResponseEntity.noContent().build();
+    }
+
+}

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/controller/UserController.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/controller/UserController.java
@@ -1,0 +1,31 @@
+package org.nhnacademy.book2onandonbookservice.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.nhnacademy.book2onandonbookservice.dto.review.ReviewDto;
+import org.nhnacademy.book2onandonbookservice.service.review.ReviewService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/users")
+public class UserController {
+    private final ReviewService reviewService;
+
+    //특정 유저에대한 리뷰 목록
+    @GetMapping(value = "/{userId}/reviews")
+    public ResponseEntity<Page<ReviewDto>> getUserReviewList(@PathVariable Long userId,
+                                                             @PageableDefault(page = 0, size = 10, sort = "createdAt", direction = Direction.DESC) Pageable pageable) {
+        Page<ReviewDto> reviewPage = reviewService.getReviewListByUserId(userId, pageable);
+        return ResponseEntity.ok(reviewPage);
+    }
+
+
+}

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/dto/DataParserDto.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/dto/DataParserDto.java
@@ -2,7 +2,6 @@ package org.nhnacademy.book2onandonbookservice.dto;
 
 import java.time.LocalDate;
 import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
@@ -32,9 +31,6 @@ public class DataParserDto {
     private final List<String> translators;
 
     private final String imageUrl;
-
-    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-    private static final DateTimeFormatter DATE_FORMATTER_NO_DASH = DateTimeFormatter.ofPattern("yyyyMMdd");
 
     private static final String[] PARSE_PATTERS = {
             "yyyy-MM-dd",

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/dto/api/AladinApiResponse.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/dto/api/AladinApiResponse.java
@@ -25,5 +25,6 @@ public class AladinApiResponse {
         private String description;
         private String categoryName;
         private String cover; // 이미지 URL
+
     }
 }

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/dto/book/BookDetailResponse.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/dto/book/BookDetailResponse.java
@@ -1,13 +1,18 @@
 package org.nhnacademy.book2onandonbookservice.dto.book;
 
 import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.Getter;
 import org.nhnacademy.book2onandonbookservice.dto.common.CategoryDto;
 import org.nhnacademy.book2onandonbookservice.dto.common.PublisherDto;
 import org.nhnacademy.book2onandonbookservice.dto.common.TagDto;
 import org.nhnacademy.book2onandonbookservice.dto.review.ReviewDto;
+import org.nhnacademy.book2onandonbookservice.entity.Book;
+import org.nhnacademy.book2onandonbookservice.entity.BookImage;
+import org.nhnacademy.book2onandonbookservice.entity.Review;
 
 // 도서 상세 페이지 출력
 @Getter
@@ -43,6 +48,79 @@ public class BookDetailResponse {
     private Boolean likedByCurrentUser; // 사용자가 좋아요를 눌렀는지의 여부
 
     private List<ReviewDto> reviews;   // 상위 몇 개만
-    private Double averageScore;       // 평균 평점
+    private Double rating;       // 평균 평점
     private Long reviewCount;          // 전체 리뷰 개수
+
+
+    /// 헬퍼 메서드
+    public static BookDetailResponse from(Book book, Long currentUserId) {
+        //작가 이름 연결
+        String contributors = book.getBookContributors().stream()
+                .map(bc -> bc.getContributor().getContributorName())
+                .collect(Collectors.joining(", "));
+
+        //대표이미지 추출
+        String thumbnail = book.getImages().stream()
+                .findFirst()
+                .map(BookImage::getImagePath)
+                .orElse("/images/no-image.png");
+
+        // 좋아요 여부 확인
+        boolean isLiked = false;
+        if (currentUserId != null) {
+            isLiked = book.getLikes().stream()
+                    .anyMatch(like -> like.getUserId().equals(currentUserId));
+        }
+
+        List<CategoryDto> categoryDtos = book.getBookCategories().stream()
+                .map(bc -> CategoryDto.builder()
+                        .id(bc.getCategory().getId())
+                        .name(bc.getCategory().getCategoryName())
+                        .build())
+                .toList();
+
+        List<TagDto> tagDtos = book.getBookTags().stream()
+                .map(bt -> TagDto.builder()
+                        .id(bt.getTag().getId())
+                        .name(bt.getTag().getTagName())
+                        .build())
+                .toList();
+
+        List<PublisherDto> publisherDtos = book.getBookPublishers().stream()
+                .map(bp -> PublisherDto.builder()
+                        .id(bp.getPublisher().getId())
+                        .name(bp.getPublisher().getPublisherName())
+                        .build())
+                .toList();
+
+        List<ReviewDto> previewReviews = book.getReviews().stream()
+                .sorted(Comparator.comparing(Review::getCreatedAt).reversed())
+                .limit(3)
+                .map(ReviewDto::from)
+                .toList();
+
+        return BookDetailResponse.builder()
+                .id(book.getId()) // Entity 필드명은 id 입니다.
+                .isbn(book.getIsbn())
+                .title(book.getTitle())
+                .volume(book.getVolume())
+                .contributorName(contributors)
+                .publishDate(book.getPublishDate())
+                .publishers(publisherDtos)
+                .priceStandard(book.getPriceStandard())
+                .priceSales(book.getPriceSales())
+                .stockStatus(book.getStockStatus())
+                .categories(categoryDtos)
+                .tags(tagDtos)
+                .isWrapped(book.getIsWrapped())
+                .imagePath(thumbnail)
+                .chapter(book.getChapter())
+                .descriptionHtml(book.getDescription())
+                .likeCount((long) book.getLikes().size()) // List 크기로 계산
+                .likedByCurrentUser(isLiked)
+                .rating(book.getRating()) // 추가된 평점 필드
+                .reviewCount((long) book.getReviews().size()) // List 크기로 계산
+                .reviews(previewReviews)
+                .build();
+    }
 }

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/dto/error/ErrorResponse.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/dto/error/ErrorResponse.java
@@ -1,0 +1,19 @@
+package org.nhnacademy.book2onandonbookservice.dto.error;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+public class ErrorResponse {
+    private final LocalDateTime timestamp;
+    private final int status;
+    private final String error;
+    private final String message;
+
+    public ErrorResponse(LocalDateTime timestamp, int status, String error, String message) {
+        this.timestamp = timestamp;
+        this.status = status;
+        this.error = error;
+        this.message = message;
+    }
+}

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/dto/review/ReviewDto.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/dto/review/ReviewDto.java
@@ -1,11 +1,12 @@
 package org.nhnacademy.book2onandonbookservice.dto.review;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.nhnacademy.book2onandonbookservice.entity.Review;
 
 // 리뷰 응답
 @AllArgsConstructor
@@ -20,8 +21,32 @@ public class ReviewDto {
     private String title;   // 리뷰 제목
     private String content; // 리뷰 내용
     private Integer score;  // 평가 점수
-    private LocalDateTime createdAt;    // 리뷰 생성 일시
+    private LocalDate createdAt;    // 리뷰 생성 일시
 
 
     private List<ReviewImageDto> images;    // 이미지 경로 저장 리스트
+
+
+    /// 헬퍼 메소드
+    public static ReviewDto from(Review review) {
+
+        //리뷰에 달린 이미지 엔티티들을 문자열(URL) 리스트로 변환
+        List<ReviewImageDto> images = review.getImages().stream()
+                .map(image -> ReviewImageDto.builder()
+                        .id(image.getId())
+                        .imagePath(image.getImagePath())
+                        .build()) // 이미지 객체에서 경로만 쏙 뺌
+                .toList();
+
+        // 빌더로 DTO 생성 후 반환
+        return ReviewDto.builder()
+                .id(review.getId())
+                .userId(review.getUserId()) // 닉네임이 필요하면 User-Service 통신 필요 (일단 ID로)
+                .title(review.getTitle())
+                .content(review.getContent())
+                .score(review.getScore())
+                .createdAt(review.getCreatedAt().toLocalDate())
+                .images(images)
+                .build();
+    }
 }

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/dto/review/ReviewUpdateRequest.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/dto/review/ReviewUpdateRequest.java
@@ -3,18 +3,16 @@ package org.nhnacademy.book2onandonbookservice.dto.review;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import java.util.List;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.validator.constraints.Length;
 
-// 리뷰 작성 요청
-@AllArgsConstructor
 @Getter
 @NoArgsConstructor
-@Builder
-public class ReviewCreateRequest {
+@AllArgsConstructor
+public class ReviewUpdateRequest {
 
     @NotNull(message = "리뷰 제목은 필수입니다.")
     private String title;   // 리뷰 제목
@@ -28,4 +26,5 @@ public class ReviewCreateRequest {
     @Max(value = 5, message = "별점은 최대 5점입니다.")
     private Integer score;  // 평가 점수
 
+    private List<Long> deleteImageIds;
 }

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/entity/Book.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/entity/Book.java
@@ -64,6 +64,11 @@ public class Book {
     @Column(name = "price_standard", nullable = false)
     private Long priceStandard;
 
+    //평점
+    @Column(name = "book_rating") // DB 컬럼명
+    @Builder.Default // 빌더 패턴 사용 시 기본값 적용되도록 함
+    private Double rating = 0.0;
+
     // 포장 여부 ->  해당 책이 포장이 가능한지, 아닌지
     @Setter
     @Column(name = "is_wrapped", nullable = false)
@@ -159,6 +164,10 @@ public class Book {
                         .publisher(publisher)
                         .build()
         );
+    }
+
+    public void updateRating(Double newRating) {
+        this.rating = newRating;
     }
 
 }

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/entity/Review.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/entity/Review.java
@@ -73,4 +73,12 @@ public class Review {
     @Builder.Default
     @Setter
     private List<ReviewImage> images = new ArrayList<>();
+
+
+    /// 헬퍼 메소드
+    public void update(String title, String content, Integer score) {
+        this.title = title;
+        this.content = content;
+        this.score = score;
+    }
 }

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/exception/GlobalExceptionHandler.java
@@ -1,0 +1,59 @@
+package org.nhnacademy.book2onandonbookservice.exception;
+
+
+import java.time.LocalDateTime;
+import org.nhnacademy.book2onandonbookservice.dto.error.ErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    /**
+     * [404] NotFoundBookException , NotFoundReviewException
+     */
+    @ExceptionHandler({NotFoundBookException.class, NotFoundReviewException.class})
+    public ResponseEntity<ErrorResponse> handleNotFoundBookException(Exception ex) {
+        ErrorResponse response = new ErrorResponse(
+                LocalDateTime.now(),
+                HttpStatus.NOT_FOUND.value(),
+                "Not Found",
+                ex.getMessage()
+        );
+        return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
+    }
+
+    /**
+     * [400] @Vaild 유효성 검사 실패 시 처리 (DTO 에서 NOTNULL 등 걸렸을떄)
+     */
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException ex) {
+        // 첫 번째 에러 메시지만 뽑아서 보여줌
+        String errorMessage = ex.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+
+        ErrorResponse response = new ErrorResponse(
+                LocalDateTime.now(),
+                HttpStatus.BAD_REQUEST.value(),
+                "Bad Request",
+                errorMessage
+        );
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
+    /**
+     * [500] 그 외 나머지 모든 에러 처리 (안전망)
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleGlobalException(Exception ex) {
+        ErrorResponse response = new ErrorResponse(
+                LocalDateTime.now(),
+                HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                "Internal Server Error",
+                "서버 내부 오류가 발생했습니다. 관리자에게 문의하세요."
+        );
+        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/exception/NotFoundBookException.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/exception/NotFoundBookException.java
@@ -1,0 +1,7 @@
+package org.nhnacademy.book2onandonbookservice.exception;
+
+public class NotFoundBookException extends RuntimeException {
+    public NotFoundBookException(Long bookId) {
+        super("해당 도서를 찾을 수 없습니다 ID: " + bookId);
+    }
+}

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/exception/NotFoundReviewException.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/exception/NotFoundReviewException.java
@@ -1,0 +1,7 @@
+package org.nhnacademy.book2onandonbookservice.exception;
+
+public class NotFoundReviewException extends RuntimeException {
+    public NotFoundReviewException(Long reviewId) {
+        super("해당 도서를 찾을 수 없습니다 ID: " + reviewId);
+    }
+}

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/repository/ReviewRepository.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/repository/ReviewRepository.java
@@ -1,7 +1,20 @@
 package org.nhnacademy.book2onandonbookservice.repository;
 
+import org.nhnacademy.book2onandonbookservice.entity.Book;
 import org.nhnacademy.book2onandonbookservice.entity.Review;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
+    boolean existsByBookIdAndUserId(Long bookId, Long userId);
+
+    Page<Review> findAllByBook(Book book, Pageable pageable);
+
+    @Query("SELECT AVG(r.score) FROM Review r WHERE r.book= :book")
+    Double getAverageScoreByBook(@Param("book") Book book);
+
+    Page<Review> findAllByUserId(Long userId, Pageable pageable);
 }

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/service/image/ImageUploadService.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/service/image/ImageUploadService.java
@@ -2,13 +2,18 @@ package org.nhnacademy.book2onandonbookservice.service.image;
 
 import io.minio.MinioClient;
 import io.minio.PutObjectArgs;
+import io.minio.RemoveObjectArgs;
 import java.io.InputStream;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
+@Slf4j
 public class ImageUploadService {
     private final MinioClient minioClient;
 
@@ -84,4 +89,37 @@ public class ImageUploadService {
             throw new RuntimeException("이미지 업로드 실패", e);
         }
     }
+
+    /**
+     * 공통 파일 삭제 로직 Book 이미지든 Review 이미지든 MINIO 면 삭제
+     */
+
+    public void remove(String imageUrl) {
+        if (imageUrl == null || imageUrl.isEmpty()) {
+            return;
+        }
+        try {
+            String minioPrefix = minioUrl + "/" + rootBucket + "/";
+
+            if (!imageUrl.startsWith(minioPrefix)) {
+                log.info("외부 링크이므로 삭제 건너뜀: {}", imageUrl);
+                return;
+            }
+
+            String objectName = imageUrl.substring(minioPrefix.length());
+            objectName = URLDecoder.decode(objectName, StandardCharsets.UTF_8);
+
+            minioClient.removeObject(RemoveObjectArgs.builder()
+                    .bucket(rootBucket)
+                    .object(objectName)
+                    .build()
+            );
+
+            log.info("MINIO 삭제 성공: {}", objectName);
+        } catch (Exception e) {
+            log.error("MINIO 이미지 삭제 실패 : URL={}", imageUrl, e);
+        }
+    }
+
+
 }

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/service/review/Impl/ReviewServiceImpl.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/service/review/Impl/ReviewServiceImpl.java
@@ -1,0 +1,192 @@
+package org.nhnacademy.book2onandonbookservice.service.review.Impl;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.nhnacademy.book2onandonbookservice.client.OrderServiceClient;
+import org.nhnacademy.book2onandonbookservice.dto.review.ReviewCreateRequest;
+import org.nhnacademy.book2onandonbookservice.dto.review.ReviewDto;
+import org.nhnacademy.book2onandonbookservice.dto.review.ReviewUpdateRequest;
+import org.nhnacademy.book2onandonbookservice.entity.Book;
+import org.nhnacademy.book2onandonbookservice.entity.Review;
+import org.nhnacademy.book2onandonbookservice.entity.ReviewImage;
+import org.nhnacademy.book2onandonbookservice.exception.NotFoundBookException;
+import org.nhnacademy.book2onandonbookservice.exception.NotFoundReviewException;
+import org.nhnacademy.book2onandonbookservice.repository.BookRepository;
+import org.nhnacademy.book2onandonbookservice.repository.ReviewRepository;
+import org.nhnacademy.book2onandonbookservice.service.image.ImageUploadService;
+import org.nhnacademy.book2onandonbookservice.service.review.ReviewService;
+import org.nhnacademy.book2onandonbookservice.util.UserHeaderUtil;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ReviewServiceImpl implements ReviewService {
+    private final ReviewRepository reviewRepository;
+
+    private final BookRepository bookRepository;
+
+    private final OrderServiceClient orderServiceClient;
+
+    private final ImageUploadService imageUploadService;
+
+    private final UserHeaderUtil util;
+
+
+    /// 리뷰생성
+    @Override
+    public Long createReview(Long bookId, ReviewCreateRequest req, List<MultipartFile> image) {
+        Book book = bookRepository.findById(bookId).orElseThrow(() -> new NotFoundBookException(bookId));
+        Long userId = util.getUserId();
+        //order-service에 유저가 해당 도서를 구매하고 배송이 완료된 후 리뷰를 작성하는지 검증
+        boolean isPurchased = orderServiceClient.hasPurchased(userId, bookId);
+        if (!isPurchased) {
+            throw new IllegalArgumentException("해당 도서를 구매후 배송이 완료된 회원만 리뷰 작성 가능합니다.");
+        }
+
+        if (reviewRepository.existsByBookIdAndUserId(bookId, userId)) {
+            throw new IllegalArgumentException("이미 해당 도서에 대한 리뷰를 작성했습니다.");
+        }
+
+        Review review = Review.builder()
+                .book(book)
+                .userId(userId)
+                .title(req.getTitle())
+                .content(req.getContent())
+                .score(req.getScore())
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        if (image != null && !image.isEmpty()) {
+            for (MultipartFile file : image) {
+                if (!file.isEmpty()) {
+                    String imageUrl = imageUploadService.uploadReviewImage(file);
+
+                    ReviewImage reviewImage = ReviewImage.builder()
+                            .book(book)
+                            .review(review)
+                            .imagePath(imageUrl)
+                            .build();
+
+                    review.getImages().add(reviewImage);
+                }
+            }
+        }
+
+        reviewRepository.save(review);
+
+        updateBookRating(book);
+
+        return review.getId();
+    }
+
+
+    /// 특정 책에 대한 리뷰 목록
+    @Override
+    public Page<ReviewDto> getReviewListByBookId(Long bookId, Pageable pageable) {
+        Book book = bookRepository.findById(bookId).orElseThrow(() -> new NotFoundBookException(bookId));
+        Page<Review> reviewPage = reviewRepository.findAllByBook(book, pageable);
+
+        return reviewPage.map(ReviewDto::from);
+    }
+
+    /// 특정 유저에 대한 리뷰 목록
+    @Override
+    public Page<ReviewDto> getReviewListByUserId(Long userId, Pageable pageable) {
+        Page<Review> reviewPage = reviewRepository.findAllByUserId(userId, pageable);
+        return reviewPage.map(ReviewDto::from);
+    }
+
+    /*
+    프론트엔드 구현 팁:
+
+    수정 화면을 그릴 때, 기존 이미지 옆에 [X] 버튼을 둠.
+
+    사용자가 [X]를 누르면 화면에서 이미지를 숨기고, 그 이미지의 ID를 deleteImageIds 배열에 담음
+
+    수정 완료를 누르면 이 ID 목록과, 새로 추가한 파일들을 함께 서버로 보냄
+     */
+
+    /// 특정 리뷰 수정
+    @Override
+    public void updateReview(Long reviewId, ReviewUpdateRequest request, List<MultipartFile> images) {
+        //1. DB에서 데이터를 가져오면, JPA는 이 객체를 영속성 컨텍스트 보관소에 넣고 최초 상태를 찍어둠
+        Review review = reviewRepository.findById(reviewId).orElseThrow(() -> new NotFoundReviewException(reviewId));
+
+        Long currentId = util.getUserId();
+        if (!review.getUserId().equals(currentId)) {
+            throw new AccessDeniedException("본인의 리뷰만 수정할 수 있습니다.");
+        }
+        //더티 체킹 (@Transactional 덕분에 가능함)
+        //2. 자바 객체의 값을 바꿈 (아직 DB에 간게 아니라 메모리 상의 객체만 바뀐 상태
+        review.update(request.getTitle(), request.getContent(), request.getScore());
+
+        if (request.getDeleteImageIds() != null && !request.getDeleteImageIds().isEmpty()) {
+            review.getImages().removeIf(image -> {
+                if (request.getDeleteImageIds().contains(image.getId())) {
+                    imageUploadService.remove(image.getImagePath());
+                    return true;
+                }
+                return false;
+            });
+        }
+
+        if (images != null && !images.isEmpty()) {
+            for (MultipartFile file : images) {
+                if (!file.isEmpty()) {
+                    String imageUrl = imageUploadService.uploadReviewImage(file);
+
+                    ReviewImage newImage = ReviewImage.builder()
+                            .review(review)
+                            .book(review.getBook())
+                            .imagePath(imageUrl)
+                            .build();
+
+                    review.getImages().add(newImage);
+                }
+            }
+        }
+        updateBookRating(review.getBook());
+        //3. 트랜잭션 종료 - JPA는 최초 상태와 현재 객체 상태를 비교해서 수정이 일어난게 보이면 바꼈다고 생각하고 자동반영
+    }
+
+    /// 특정 리뷰 삭제
+    @Override
+    public void deleteReview(Long reviewId) {
+        Review review = reviewRepository.findById(reviewId).orElseThrow(() -> new NotFoundReviewException(reviewId));
+
+        Long currentId = util.getUserId();
+        if (!review.getUserId().equals(currentId)) {
+            throw new AccessDeniedException("본인의 리뷰만 삭제할 수 있습니다.");
+        }
+
+        Book book = review.getBook();
+        reviewRepository.delete(review); // entityManager.remove(review)가 실행됨
+        updateBookRating(book);
+        //트랜잭션이 끝날때 진짜 DELETE가 DB로 날아감
+    }
+
+    /// 내부 로직 메서드
+    //평점 업데이트 로직
+    private void updateBookRating(Book book) {
+        Double average = reviewRepository.getAverageScoreByBook(book);
+
+        if (average == null) {
+            book.updateRating(0.0);
+            return;
+        }
+
+        double roundedAverage = Math.round(average * 10.0) / 10.0;
+        book.updateRating(roundedAverage);
+    }
+
+
+}

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/service/review/ReviewService.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/service/review/ReviewService.java
@@ -1,0 +1,23 @@
+package org.nhnacademy.book2onandonbookservice.service.review;
+
+import java.util.List;
+import org.nhnacademy.book2onandonbookservice.dto.review.ReviewCreateRequest;
+import org.nhnacademy.book2onandonbookservice.dto.review.ReviewDto;
+import org.nhnacademy.book2onandonbookservice.dto.review.ReviewUpdateRequest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface ReviewService {
+    Long createReview(Long bookId, ReviewCreateRequest req, List<MultipartFile> image);
+
+    /// 특정 책에 대한 리뷰목록
+    Page<ReviewDto> getReviewListByBookId(Long bookId, Pageable pageable);
+
+    /// 특정 유저에 대한 리뷰목록
+    Page<ReviewDto> getReviewListByUserId(Long userId, Pageable pageable);
+
+    void updateReview(Long reviewId, ReviewUpdateRequest request, List<MultipartFile> images);
+
+    void deleteReview(Long reviewId);
+}

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/util/UserHeaderUtil.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/util/UserHeaderUtil.java
@@ -8,8 +8,8 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 @Component
 public class UserHeaderUtil {
 
-    private static final String HEADER_USER_ID = "X-USER-ID";
-    private static final String HEADER_USER_ROLE = "X-USER-ROLE";
+    private static final String HEADER_USER_ID = "X-User-Id";
+    private static final String HEADER_USER_ROLE = "X-User-Role";
 
     public Long getUserId() {
         HttpServletRequest request = getRequest();
@@ -29,10 +29,16 @@ public class UserHeaderUtil {
         }
     }
 
+    /**
+     * ROLE_USER: 일반 회원 ROLE_BOOK_ADMIN:
+     *
+     * @return
+     */
     public String getUserRole() {
         HttpServletRequest request = getRequest();
         return (request != null) ? request.getHeader(HEADER_USER_ROLE) : null;
     }
+
 
     private HttpServletRequest getRequest() {
         ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes(); // spring은 요청이 들어오면 저 컨텍스트 홀더에 요청 정보를 저장해 두기 때문에 홀더에서 꺼내씀


### PR DESCRIPTION
## 🔀 PR 개요

도서 상세 페이지의 핵심 기능인 리뷰(Review) 시스템을 구현했습니다.
사용자는 구매한 도서에 대해 별점과 이미지를 포함한 리뷰를 작성할 수 있으며, 이에 따라 도서의 평균 평점이 실시간으로 갱신됩니다.

---

## 📄 변경 사항


- [x] 새로운 기능 추가 (✨ Feature)
- [ ] 버그 수정 (🐞 BugFix)
- [x] 코드 리팩토링 (🔧 Refactor)
- [ ] 문서 수정 (📝 Docs)
- [ ] 테스트 코드 추가 (🧪 Test)
- [ ] 배포 관련 (🚀 Deploy)
- [ ] 기타 설정 변경 (🧰 Setting)


1. 리뷰 CRUD API 구현

등록: Order-Service와 통신하여 구매 확정 여부를 검증 후 등록 (1인 1리뷰 제한).

조회: 도서별(페이징), 유저별(내 리뷰) 목록 조회 구현.

수정/삭제: 작성자 본인 확인 로직 및 Dirty Checking을 이용한 업데이트.

2. 이미지 처리 로직 고도화 (MinIO)

업로드: 리뷰 등록/수정 시 이미지를 MinIO에 업로드하고 ReviewImage 엔티티로 저장.

삭제: 리뷰 삭제 또는 수정 시, MinIO에 저장된 실제 파일도 함께 삭제되도록 로직 구현.

알라딘 API 등 외부 URL 이미지는 건너뛰고, 내부 스토리지(MinIO) 파일만 식별하여 삭제하는 방어 로직 추가.

3. 도서 평점 연동

리뷰 등록/수정/삭제 시점에 ReviewRepository의 JPQL(AVG)을 사용하여 해당 도서의 평균 평점을 재계산하고 Book 엔티티에 반영.

4. 공통 예외 처리 및 유틸리티

GlobalExceptionHandler 도입: NotFoundBookException, AccessDeniedException 등 전역 예외 처리.

UserHeaderUtil 적용: Gateway에서 넘어온 유저 정보를 Controller가 아닌 Service 계층에서 깔끔하게 핸들링.

---

## 💡 변경 이유

구매자 검증: 무분별한 리뷰 작성을 막고 신뢰도를 높이기 위해 구매 인증 로직이 필수적임.

스토리지 최적화: 리뷰가 삭제되었을 때 불필요한 이미지 파일이 스토리지에 남는 것을 방지하기 위해 삭제 로직을 동기화함.

성능 최적화: 도서 목록 조회 시 매번 리뷰 평점을 계산하는 비용을 줄이기 위해, 리뷰 변경 시점에 Book 테이블의 rating 컬럼을 갱신하는 방식 채택.

---

## 🧩 관련 이슈

Closes #54 #55 
---
