### PR TITLE
feat: 도서 큐레이션(베스트셀러/신간) 로직 구현 및 BookService 단위 테스트 작성

### DIFF
--- a/http/req.http
+++ b/http/req.http
@@ -155,3 +155,61 @@ Content-Type: application/json
     }
   }
 }
+
+
+###
+GET http://s4.java21.net:9200/_cat/plugins?v
+Authorization: Basic elastic nhnacademy123!
+
+###
+POST http://s4.java21.net:9200/book2onandon-books/_analyze
+Content-Type: application/json
+Authorization: Basic elastic nhnacademy123!
+
+{
+  "analyzer": "korean_nori_analyzer",
+  "text": "아버지가방에들어가신다"
+}
+
+### 1. 기존 인덱스 삭제
+DELETE http://s4.java21.net:9200/book2onandon-books
+Authorization: Basic elastic nhnacademy123!
+
+### 2. 인덱스 수동 생성 (분석기 설정 포함)
+PUT http://s4.java21.net:9200/book2onandon-books
+Content-Type: application/json
+Authorization: Basic elastic nhnacademy123!
+
+{
+  "settings": {
+    "analysis": {
+      "tokenizer": {
+        "nori_none_mixed": {
+          "type": "nori_tokenizer",
+          "decompound_mode": "mixed"
+        }
+      },
+      "analyzer": {
+        "korean_nori_analyzer": {
+          "type": "custom",
+          "tokenizer": "nori_none_mixed",
+          "filter": [
+            "lowercase",
+            "nori_readingform",
+            "nori_part_of_speech"
+          ]
+        }
+      }
+    }
+  }
+}
+
+### 3. 형태소 분석 테스트
+POST http://s4.java21.net:9200/book2onandon-books/_analyze
+Content-Type: application/json
+Authorization: Basic elastic nhnacademy123!
+
+{
+  "analyzer": "korean_nori_analyzer",
+  "text": "아버지가방에들어가신다"
+}

--- a/logs/parsing.log
+++ b/logs/parsing.log
@@ -122,3 +122,10 @@ Caused by: java.lang.IllegalStateException: EntityManagerFactory is closed
 2025-11-27 19:24:04 [restartedMain] INFO  o.n.b.config.DataInitializer - 데이터가 이미 존재합니다. 초기화를 건너뜁니다.
 2025-11-27 19:28:19 [restartedMain] INFO  o.n.b.config.DataInitializer - 데이터가 이미 존재합니다. 초기화를 건너뜁니다.
 2025-11-27 19:39:18 [restartedMain] INFO  o.n.b.config.DataInitializer - 데이터가 이미 존재합니다. 초기화를 건너뜁니다.
+2025-11-28 12:36:59 [restartedMain] INFO  o.n.b.config.DataInitializer - 데이터가 이미 존재합니다. 초기화를 건너뜁니다.
+2025-11-28 13:04:59 [restartedMain] INFO  o.n.b.config.DataInitializer - 데이터가 이미 존재합니다. 초기화를 건너뜁니다.
+2025-11-28 13:08:23 [restartedMain] INFO  o.n.b.config.DataInitializer - 데이터가 이미 존재합니다. 초기화를 건너뜁니다.
+2025-11-28 13:08:37 [restartedMain] INFO  o.n.b.config.DataInitializer - 데이터가 이미 존재합니다. 초기화를 건너뜁니다.
+2025-11-28 13:11:22 [restartedMain] INFO  o.n.b.config.DataInitializer - 데이터가 이미 존재합니다. 초기화를 건너뜁니다.
+2025-11-28 13:11:37 [restartedMain] INFO  o.n.b.config.DataInitializer - 데이터가 이미 존재합니다. 초기화를 건너뜁니다.
+2025-11-28 13:22:56 [restartedMain] INFO  o.n.b.config.DataInitializer - 데이터가 이미 존재합니다. 초기화를 건너뜁니다.

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/client/AladinApiClient.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/client/AladinApiClient.java
@@ -25,7 +25,7 @@ public class AladinApiClient {
     private String ttbKey;
 
 
-    @Cacheable(value = "aladinBook", key = "#isbn", unless = "#result == null")
+    @Cacheable(value = "aladinBook", key = "#isbn", unless = "#result == null", cacheManager = "RedisCacheManager")
     public AladinApiResponse.Item searchByIsbn(String isbn) {
         if (isbn == null || isbn.isBlank()) {
             return null;

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/client/GeminiApiClient.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/client/GeminiApiClient.java
@@ -56,7 +56,7 @@ public class GeminiApiClient {
         return apiKeys[index];
     }
 
-    @Cacheable(value = "geminiTags", key = "#title", unless = "#result == null || #result.isEmpty()")
+    @Cacheable(value = "geminiTags", key = "#title", unless = "#result == null || #result.isEmpty()", cacheManager = "RedisCacheManager")
     public List<String> extractTags(String title, String description) {
         if (description == null || description.isEmpty()) {
             return Collections.emptyList();

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/client/OrderServiceClient.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/client/OrderServiceClient.java
@@ -1,9 +1,11 @@
 package org.nhnacademy.book2onandonbookservice.client;
 
+import java.util.List;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
 
 //주문쪽에 요청 보낼때만 사용
 @FeignClient(name = "ORDER-SERVICE")
@@ -11,4 +13,9 @@ public interface OrderServiceClient {
 
     @GetMapping("orders/check-purchase/{bookId}")
     boolean hasPurchased(@RequestHeader("X-User-Id") Long userId, @PathVariable Long bookId);
+
+    /// 판매량 순 period=DAILY, WEEKLY GET /orders/bestsellers?period=DAILY GET /orders/bestsellers?period=WEEKLY
+    @GetMapping("orders/bestsellers")
+    List<Long> getBestSellersBookIds(@RequestParam("period") String period);
+
 }

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/config/RedisConfig.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/config/RedisConfig.java
@@ -2,6 +2,8 @@ package org.nhnacademy.book2onandonbookservice.config;
 
 
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -17,7 +19,7 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 public class RedisConfig {
 
     @Bean //Redis가 캐시매니저인걸 EnableCaching으로 알려줌 그럼 Cacheable 어노테이션이 붙은 메서드가 호출되면 자동으로 Redis에 데이터를 저장하고 조회함
-    public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+    public RedisCacheManager RedisCacheManager(RedisConnectionFactory connectionFactory) {
         RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
                 .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(
                         new StringRedisSerializer())) //키는 String 으로 직렬화
@@ -25,9 +27,11 @@ public class RedisConfig {
                         new GenericJackson2JsonRedisSerializer())) // 값은 Json으로 직렬화
                 .entryTtl(Duration.ofDays(7)) // 캐시 유효시간 (TTL) 기본 7일 설정 (책 정보는 잘 안 바뀌기때문에 길게 잡는 것이 좋음)
                 .disableCachingNullValues();
-
+        Map<String, RedisCacheConfiguration> cacheConfigurations = new HashMap<>();
+        cacheConfigurations.put("bestsellers", config.entryTtl(Duration.ofHours(12)));
         return RedisCacheManager.builder(connectionFactory)
                 .cacheDefaults(config)
+                .withInitialCacheConfigurations(cacheConfigurations)
                 .build();
     }
 }

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/controller/BookController.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/controller/BookController.java
@@ -14,6 +14,7 @@ import org.nhnacademy.book2onandonbookservice.service.book.BookService;
 import org.nhnacademy.book2onandonbookservice.service.image.ImageUploadService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -109,5 +110,21 @@ public class BookController {
         bookService.deleteBook(bookId); // DB 삭제 + ES 인덱스 삭제 포함
 
         return ResponseEntity.noContent().build(); // 204
+    }
+
+    /// 베스트셀러 조회 API GET /books/bestsellers?period=DAILY
+    @GetMapping("/bestsellers")
+    public ResponseEntity<List<BookListResponse>> getBestsellers(@RequestParam("period") String period) {
+        List<BookListResponse> bestsellers = bookService.getBestsellers(period.toUpperCase());
+        return ResponseEntity.ok(bestsellers);
+    }
+
+    /// 신간 도서 조회 GET /books/new-arrivals?categoryId=10&size=20
+    @GetMapping("/new-arrivals")
+    public ResponseEntity<Page<BookListResponse>> getNewArrivals(
+            @RequestParam(value = "categoryId", required = false) Long categoryId,
+            @PageableDefault(sort = "publishDate", direction = Direction.DESC) Pageable pageable) {
+        Page<BookListResponse> newArrivals = bookService.getNewArrivals(categoryId, pageable);
+        return ResponseEntity.ok(newArrivals);
     }
 }

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/dto/book/BookListResponse.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/dto/book/BookListResponse.java
@@ -1,8 +1,12 @@
 package org.nhnacademy.book2onandonbookservice.dto.book;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.Getter;
+import org.nhnacademy.book2onandonbookservice.entity.Book;
+import org.nhnacademy.book2onandonbookservice.entity.BookImage;
 
 // 도서 검색 시 여러 권을 리스트로 보여주는(조회하는) DTO
 @Getter
@@ -14,11 +18,47 @@ public class BookListResponse {
 
     private Long priceStandard; // 도서 정가
     private Long priceSales; // 도서 판매가
-
+    private Double rating; //평점
     private String imagePath;   // 도서 이미지
+    private LocalDate publisherDate;
 
     private List<String> contributorNames;  // 기여자 정보
     private List<String> publisherNames;    // 출판사
     private List<String> categoryIds;   // 카테고리
     private List<String> tagNames;  // 태그
+
+
+    public static BookListResponse from(Book book) {
+        String mainImagePath = book.getImages().stream()
+                .findFirst()
+                .map(BookImage::getImagePath)
+                .orElse(null);
+
+        return BookListResponse.builder()
+                .id(book.getId())
+                .title(book.getTitle())
+                .volume(book.getVolume())
+                .priceStandard(book.getPriceStandard())
+                .priceSales(book.getPriceSales())
+                .rating(book.getRating())
+                .publisherDate(book.getPublishDate())
+                .imagePath(mainImagePath)
+                .contributorNames(book.getBookContributors().stream()
+                        .map(bc -> bc.getContributor().getContributorName())
+                        .collect(Collectors.toList())
+                )
+                .publisherNames(book.getBookPublishers().stream()
+                        .map(bp -> bp.getPublisher().getPublisherName())
+                        .collect(Collectors.toList())
+                )
+                .categoryIds(book.getBookCategories().stream()
+                        .map(bc -> bc.getCategory().getCategoryName())
+                        .collect(Collectors.toList())
+                )
+                .tagNames(book.getBookTags().stream()
+                        .map(bt -> bt.getTag().getTagName())
+                        .collect(Collectors.toList())
+                ).build();
+    }
+
 }

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/repository/BookRepository.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/repository/BookRepository.java
@@ -3,9 +3,11 @@ package org.nhnacademy.book2onandonbookservice.repository;
 import java.util.List;
 import java.util.Optional;
 import org.nhnacademy.book2onandonbookservice.entity.Book;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface BookRepository extends JpaRepository<Book, Long> {
 
@@ -25,7 +27,7 @@ public interface BookRepository extends JpaRepository<Book, Long> {
     List<Book> findBooksNeedingTags(Pageable pageable);
 
 
-    // 연관관계 전체 Featch Join 조회 쿼리 추가 -> Book 수정 시 연관관계를 한 번에 가져오기 위한 전용 쿼리
+    // Book 수정 시 연관관계를 한 번에 가져오기 위한 전용 쿼리
     @Query("""
             SELECT DISTINCT b FROM Book b
             LEFT JOIN FETCH b.bookCategories bc
@@ -34,6 +36,10 @@ public interface BookRepository extends JpaRepository<Book, Long> {
             """)
     Optional<Book> findByIdWithRelations(Long bookId);
 
+    @Query("SELECT b FROM Book b JOIN b.bookCategories bc WHERE bc.category.id = :categoryId ORDER BY b.publishDate DESC")
+    Page<Book> findNewArrivalsByCategoryId(@Param("categoryId") Long categoryId, Pageable pageable);
+
+    Page<Book> findAllByOrderByPublishDateDesc(Pageable pageable);
 
     interface BookIdAndIsbn {
         Long getId();

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/service/book/BookService.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/service/book/BookService.java
@@ -26,4 +26,10 @@ public interface BookService {
     BookDetailResponse getBookDetail(Long bookId, Long currentUserId);
 
     List<CategoryDto> getCategories();
+
+    //베스트셀러 조회 및 캐싱
+    List<BookListResponse> getBestsellers(String period);
+
+    //신간 도서를 출간일 최신순으로 조회하고 캐싱
+    Page<BookListResponse> getNewArrivals(Long categoryId, Pageable pageable);
 }

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/service/book/BookServiceImpl.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/service/book/BookServiceImpl.java
@@ -1,12 +1,14 @@
 package org.nhnacademy.book2onandonbookservice.service.book;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.nhnacademy.book2onandonbookservice.client.OrderServiceClient;
 import org.nhnacademy.book2onandonbookservice.dto.book.BookDetailResponse;
 import org.nhnacademy.book2onandonbookservice.dto.book.BookListResponse;
 import org.nhnacademy.book2onandonbookservice.dto.book.BookSaveRequest;
@@ -21,6 +23,7 @@ import org.nhnacademy.book2onandonbookservice.entity.BookImage;
 import org.nhnacademy.book2onandonbookservice.entity.BookPublisher;
 import org.nhnacademy.book2onandonbookservice.entity.BookTag;
 import org.nhnacademy.book2onandonbookservice.entity.Category;
+import org.nhnacademy.book2onandonbookservice.exception.NotFoundBookException;
 import org.nhnacademy.book2onandonbookservice.repository.BookLikeRepository;
 import org.nhnacademy.book2onandonbookservice.repository.BookRepository;
 import org.nhnacademy.book2onandonbookservice.repository.CategoryRepository;
@@ -47,6 +50,7 @@ public class BookServiceImpl implements BookService {
     private final CategoryRepository categoryRepository;
     private final BookSearchIndexService bookSearchIndexService;
     private final BookListResponseMapper bookListResponseMapper;
+    private final OrderServiceClient orderServiceClient;
 
     // 도서 등록
     @Override
@@ -71,7 +75,7 @@ public class BookServiceImpl implements BookService {
     @Override
     public void updateBook(Long bookId, BookSaveRequest request) {
         Book book = bookRepository.findByIdWithRelations(bookId)
-                .orElseThrow(() -> new IllegalArgumentException("도서를 찾을 수 없습니다. id = " + bookId));
+                .orElseThrow(() -> new NotFoundBookException(bookId));
 
         bookValidator.validateForUpdate(request);   // 수정값 검증
         bookFactory.updateFields(book, request);    // 단일 필드 업데이트
@@ -83,7 +87,7 @@ public class BookServiceImpl implements BookService {
     @Override
     public void deleteBook(Long bookId) {
         Book book = bookRepository.findById(bookId)
-                .orElseThrow(() -> new IllegalArgumentException("도서를 찾을 수 없습니다. id = " + bookId));
+                .orElseThrow(() -> new NotFoundBookException(bookId));
 
         // DB에서 삭제
         bookRepository.delete(book);
@@ -105,7 +109,7 @@ public class BookServiceImpl implements BookService {
     @Transactional(readOnly = true)
     public BookDetailResponse getBookDetail(Long bookId, Long currentUserId) {
         Book book = bookRepository.findByIdWithRelations(bookId)
-                .orElseThrow(() -> new IllegalArgumentException("도서를 찾을 수 없습니다. id = " + bookId));
+                .orElseThrow(() -> new NotFoundBookException(bookId));
 
         long likeCount = bookLikeRepository.countByBookId(bookId);
 
@@ -118,44 +122,78 @@ public class BookServiceImpl implements BookService {
         return toBookDetailResponse(book, likeCount, likedByCurrentUser);
     }
 
-    private BookListResponse toBookListResponse(Book book) {
-        // 대표 이미지
-        String imagePath = book.getImages().stream()
-                .findFirst()
-                .map(BookImage::getImagePath)
-                .orElse(null);
 
-        // 기여자 이름 리스트
-        List<String> contributorNames = book.getBookContributors().stream()
-                .map(bc -> bc.getContributor().getContributorName())
+    @Override
+    @Transactional(readOnly = true)
+    @Cacheable(value = "categories", unless = "#result == null || #result.isEmpty()", cacheManager = "RedisCacheManager")
+    public List<CategoryDto> getCategories() {
+        List<Category> entities = categoryRepository.findAll();
+        List<CategoryDto> allDtos = entities.stream().map(this::CategoryToDto).toList();
+        Map<Long, CategoryDto> dtoMap = allDtos.stream()
+                .collect(Collectors.toMap(CategoryDto::getId, Function.identity()));
+
+        List<CategoryDto> rootCategories = new ArrayList<>();
+
+        for (CategoryDto dto : allDtos) {
+            if (dto.getParentId() == null || dto.getParentId() == 0L) {
+                rootCategories.add(dto);
+            } else {
+                CategoryDto parent = dtoMap.get(dto.getParentId());
+                if (parent != null) {
+                    parent.getChildren().add(dto);
+                }
+            }
+        }
+        return rootCategories;
+    }
+
+    //카테고리 생성/수정/삭제 로직이 있을 경우 @CacheEvict(value="categories", allEntries=true)를 붙여줘야함
+
+    /// 베스트셀러 조회 및 캐싱
+    @Cacheable(value = "bestsellers", key = "#period", cacheManager = "RedisCacheManager") //redis
+    @Override
+    public List<BookListResponse> getBestsellers(String period) {
+        List<Long> bookIds = orderServiceClient.getBestSellersBookIds(period);
+        //기간별로 받아옵니다 DAILY, WEEK
+
+        if (bookIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<Book> books = bookRepository.findAllById(bookIds); //bookId 리스트로 관련된 book 엔티티를 찾습니다.
+
+        Map<Long, Book> bookMap = books.stream()
+                .collect(Collectors.toMap(Book::getId,
+                        Function.identity())); //Function.identity: 스트림의 요소 그 자체를 값으로 사용하는 것 Book 객체 자체
+
+        return bookIds.stream()
+                .filter(bookMap::containsKey)
+                .map(bookMap::get)
+                .map(BookListResponse::from)
                 .collect(Collectors.toList());
+    }
 
-        // 출판사 이름 리스트
-        List<String> publisherNames = book.getBookPublishers().stream()
-                .map(bp -> bp.getPublisher().getPublisherName())
-                .collect(Collectors.toList());
+    /// 신간 도서를 출간일 최신순으로 조회하고 캐싱
+    @Cacheable(value = "newArrivals", key = "#categoryId + '_' + #pageable.pageNumber", cacheManager = "RedisCacheManager")
+    @Override
+    public Page<BookListResponse> getNewArrivals(Long categoryId, Pageable pageable) {
+        Page<Book> bookPage;
 
-        // 카테고리 id 리스트 (문자열)
-        List<String> categoryIds = book.getBookCategories().stream()
-                .map(bc -> String.valueOf(bc.getCategory().getId()))
-                .collect(Collectors.toList());
+        if (categoryId != null) {
+            bookPage = bookRepository.findNewArrivalsByCategoryId(categoryId, pageable);
+        } else {
+            bookPage = bookRepository.findAllByOrderByPublishDateDesc(pageable);
+        }
+        return bookPage.map(BookListResponse::from);
+    }
 
-        // 태그 이름 리스트
-        List<String> tagNames = book.getBookTags().stream()
-                .map(bt -> bt.getTag().getTagName())
-                .collect(Collectors.toList());
 
-        return BookListResponse.builder()
-                .id(book.getId())
-                .title(book.getTitle())
-                .volume(book.getVolume())
-                .priceStandard(book.getPriceStandard())
-                .priceSales(book.getPriceSales())
-                .imagePath(imagePath)
-                .contributorNames(contributorNames)
-                .publisherNames(publisherNames)
-                .categoryIds(categoryIds)
-                .tagNames(tagNames)
+    ///    내부 로직
+    private CategoryDto CategoryToDto(Category category) {
+        return CategoryDto.builder()
+                .id(category.getId())
+                .name(category.getCategoryName())
+                .parentId(category.getParent() != null ? category.getParent().getId() : null)
                 .build();
     }
 
@@ -231,44 +269,50 @@ public class BookServiceImpl implements BookService {
                 .imagePath(imagePath)
                 .chapter(book.getChapter())
                 .descriptionHtml(book.getDescription())
+                .rating(book.getRating())
                 .likeCount(likeCount)
                 .likedByCurrentUser(likedByCurrentUser)
                 .build();
     }
 
-    @Override
-    @Transactional(readOnly = true)
-    @Cacheable(value = "categories", unless = "#result == null || #result.isEmpty()")
-    public List<CategoryDto> getCategories() {
-        List<Category> entities = categoryRepository.findAll();
-        List<CategoryDto> allDtos = entities.stream().map(this::CategoryToDto).toList();
-        Map<Long, CategoryDto> dtoMap = allDtos.stream()
-                .collect(Collectors.toMap(CategoryDto::getId, Function.identity()));
+    private BookListResponse toBookListResponse(Book book) {
+        // 대표 이미지
+        String imagePath = book.getImages().stream()
+                .findFirst()
+                .map(BookImage::getImagePath)
+                .orElse(null);
 
-        List<CategoryDto> rootCategories = new ArrayList<>();
+        // 기여자 이름 리스트
+        List<String> contributorNames = book.getBookContributors().stream()
+                .map(bc -> bc.getContributor().getContributorName())
+                .collect(Collectors.toList());
 
-        for (CategoryDto dto : allDtos) {
-            if (dto.getParentId() == null || dto.getParentId() == 0L) {
-                rootCategories.add(dto);
-            } else {
-                CategoryDto parent = dtoMap.get(dto.getParentId());
-                if (parent != null) {
-                    parent.getChildren().add(dto);
-                }
-            }
-        }
-        return rootCategories;
-    }
+        // 출판사 이름 리스트
+        List<String> publisherNames = book.getBookPublishers().stream()
+                .map(bp -> bp.getPublisher().getPublisherName())
+                .collect(Collectors.toList());
 
-    //카테고리 생성/수정/삭제 로직이 있을 경우 @CacheEvict(value="categories", allEntries=true)를 붙여줘야함
+        // 카테고리 id 리스트 (문자열)
+        List<String> categoryIds = book.getBookCategories().stream()
+                .map(bc -> String.valueOf(bc.getCategory().getId()))
+                .collect(Collectors.toList());
 
+        // 태그 이름 리스트
+        List<String> tagNames = book.getBookTags().stream()
+                .map(bt -> bt.getTag().getTagName())
+                .collect(Collectors.toList());
 
-    ///    내부 로직
-    private CategoryDto CategoryToDto(Category category) {
-        return CategoryDto.builder()
-                .id(category.getId())
-                .name(category.getCategoryName())
-                .parentId(category.getParent() != null ? category.getParent().getId() : null)
+        return BookListResponse.builder()
+                .id(book.getId())
+                .title(book.getTitle())
+                .volume(book.getVolume())
+                .priceStandard(book.getPriceStandard())
+                .priceSales(book.getPriceSales())
+                .imagePath(imagePath)
+                .contributorNames(contributorNames)
+                .publisherNames(publisherNames)
+                .categoryIds(categoryIds)
+                .tagNames(tagNames)
                 .build();
     }
 }

--- a/src/test/java/org/nhnacademy/book2onandonbookservice/service/book/BookServiceImplTest.java
+++ b/src/test/java/org/nhnacademy/book2onandonbookservice/service/book/BookServiceImplTest.java
@@ -1,0 +1,388 @@
+package org.nhnacademy.book2onandonbookservice.service.book;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.nhnacademy.book2onandonbookservice.client.OrderServiceClient;
+import org.nhnacademy.book2onandonbookservice.dto.book.BookDetailResponse;
+import org.nhnacademy.book2onandonbookservice.dto.book.BookListResponse;
+import org.nhnacademy.book2onandonbookservice.dto.book.BookSaveRequest;
+import org.nhnacademy.book2onandonbookservice.dto.book.BookSearchCondition;
+import org.nhnacademy.book2onandonbookservice.dto.common.CategoryDto;
+import org.nhnacademy.book2onandonbookservice.entity.Book;
+import org.nhnacademy.book2onandonbookservice.entity.BookCategory;
+import org.nhnacademy.book2onandonbookservice.entity.BookContributor;
+import org.nhnacademy.book2onandonbookservice.entity.BookImage;
+import org.nhnacademy.book2onandonbookservice.entity.BookPublisher;
+import org.nhnacademy.book2onandonbookservice.entity.Category;
+import org.nhnacademy.book2onandonbookservice.entity.Contributor;
+import org.nhnacademy.book2onandonbookservice.entity.Publisher;
+import org.nhnacademy.book2onandonbookservice.exception.NotFoundBookException;
+import org.nhnacademy.book2onandonbookservice.repository.BookLikeRepository;
+import org.nhnacademy.book2onandonbookservice.repository.BookRepository;
+import org.nhnacademy.book2onandonbookservice.repository.CategoryRepository;
+import org.nhnacademy.book2onandonbookservice.service.mapper.BookListResponseMapper;
+import org.nhnacademy.book2onandonbookservice.service.search.BookSearchIndexService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@ExtendWith(MockitoExtension.class)
+class BookServiceImplTest {
+
+    @InjectMocks
+    private BookServiceImpl bookService;
+
+    @Mock
+    private BookRepository bookRepository;
+    @Mock
+    private BookSearchIndexService bookSearchIndexService;
+    @Mock
+    private BookValidator bookValidator;
+    @Mock
+    private BookFactory bookFactory;
+    @Mock
+    private BookRelationService bookRelationService;
+    @Mock
+    private BookLikeRepository bookLikeRepository;
+    @Mock
+    private CategoryRepository categoryRepository;
+    @Mock
+    private BookImage mockBookImage;
+    @Mock
+    private OrderServiceClient orderServiceClient;
+
+    @Mock
+    private BookListResponseMapper bookListResponseMapper;
+
+    private Book bookA;
+    private Pageable pageable;
+
+    @BeforeEach
+    void setUp() {
+        pageable = PageRequest.of(0, 10);
+
+        Contributor mockContributorEntity = mock(Contributor.class);
+        lenient().when(mockContributorEntity.getId()).thenReturn(50L);
+        lenient().when(mockContributorEntity.getContributorName()).thenReturn("Test Author");
+
+        BookContributor mockBookContributor = mock(BookContributor.class);
+        lenient().when(mockBookContributor.getContributor()).thenReturn(mockContributorEntity);
+
+        Publisher mockPublisherEntity = mock(Publisher.class);
+        lenient().when(mockPublisherEntity.getId()).thenReturn(60L);
+        lenient().when(mockPublisherEntity.getPublisherName()).thenReturn("Test Publisher");
+
+        BookPublisher mockBookPublisher = mock(BookPublisher.class);
+        lenient().when(mockBookPublisher.getPublisher()).thenReturn(mockPublisherEntity);
+
+        Category mockCategoryEntity = mock(Category.class);
+        lenient().when(mockCategoryEntity.getId()).thenReturn(70L);
+        lenient().when(mockCategoryEntity.getCategoryName()).thenReturn("Test Category");
+
+        BookCategory mockBookCategory = mock(BookCategory.class);
+        lenient().when(mockBookCategory.getCategory()).thenReturn(mockCategoryEntity);
+
+        BookImage mockBookImage = mock(BookImage.class);
+        lenient().when(mockBookImage.getImagePath()).thenReturn("/path/to/image.jpg");
+
+        bookA = Book.builder()
+                .id(1L)
+                .title("Book A")
+                .publishDate(LocalDate.of(2023, 1, 1))
+                .priceStandard(10000L)
+                .rating(5.0)
+                .isWrapped(false)
+                .isbn("9791191370215")
+                .stockStatus(null) //null이 판매중임을 나타냄
+                .stockCount(100)
+                .priceSales(9000L)
+                .images(new HashSet<>(List.of(mockBookImage)))
+                .bookCategories(new HashSet<>(List.of(mockBookCategory)))
+                .bookContributors(new HashSet<>(List.of(mockBookContributor)))
+                .bookPublishers(new HashSet<>(List.of(mockBookPublisher)))
+                .bookTags(new HashSet<>())
+                .reviews(new HashSet<>())
+                .likes(new HashSet<>())
+                .build();
+    }
+
+    @Test
+    @DisplayName("도서 등록 성공 - DB 저장 및 ES 인덱싱 호출 검증")
+    void createBook() {
+        BookSaveRequest request = new BookSaveRequest();
+        given(bookFactory.createFrom(any(BookSaveRequest.class))).willReturn(bookA);
+        given(bookRepository.save(any(Book.class))).willReturn(bookA);
+
+        Long saveId = bookService.createBook(request);
+
+        assertThat(saveId).isEqualTo(bookA.getId());
+        verify(bookValidator, times(1)).validateForCreate(request);
+        verify(bookRepository, times(1)).save(bookA);
+        verify(bookSearchIndexService, times(1)).index(bookA);
+    }
+
+    @Test
+    @DisplayName("도서 등록 실패 - 유효성 검증 실패 (Validator 에외 전파)")
+    void createBook_Fail_Validation() {
+        BookSaveRequest request = new BookSaveRequest(); //잘못된 데이터라고 생각하기
+        willThrow(new IllegalArgumentException("도서 제목은 필수 작성 항목입니다.")).given(bookValidator).validateForCreate(request);
+        assertThatThrownBy(() -> bookService.createBook(request)).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("도서 제목은 필수 작성 항목입니다.");
+
+        willThrow(new IllegalArgumentException("ISBN은 필수 작성 항목입니다.")).given(bookValidator).validateForCreate(request);
+        assertThatThrownBy(() -> bookService.createBook(request)).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("ISBN은 필수 작성 항목입니다.");
+
+        willThrow(new IllegalArgumentException("출판일은 필수 작성 항목입니다.")).given(bookValidator).validateForCreate(request);
+        assertThatThrownBy(() -> bookService.createBook(request)).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("출판일은 필수 작성 항목입니다.");
+
+        willThrow(new IllegalArgumentException("정가는 필수입니다..")).given(bookValidator).validateForCreate(request);
+        assertThatThrownBy(() -> bookService.createBook(request)).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("정가는 필수입니다.");
+
+        willThrow(new IllegalArgumentException("정가는 0원 이상이어야 합니다.")).given(bookValidator).validateForCreate(request);
+        assertThatThrownBy(() -> bookService.createBook(request)).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("정가는 0원 이상이어야 합니다.");
+
+        willThrow(new IllegalArgumentException("판매가는 0원 이상이어야 합니다.")).given(bookValidator).validateForCreate(request);
+        assertThatThrownBy(() -> bookService.createBook(request)).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("판매가는 0원 이상이어야 합니다.");
+
+        verify(bookRepository, never()).save(any());
+    }
+
+
+    @Test
+    @DisplayName("도서 수정 성공")
+    void updateBook() {
+        Long bookId = 1L;
+        BookSaveRequest request = new BookSaveRequest();
+        given(bookRepository.findByIdWithRelations(bookId)).willReturn(Optional.of(bookA));
+
+        bookService.updateBook(bookId, request);
+
+        verify(bookFactory, times(1)).updateFields(bookA, request);
+        verify(bookRelationService, times(1)).applyRelationsForUpdate(bookA, request);
+        verify(bookSearchIndexService, times(1)).index(bookA);
+    }
+
+    @Test
+    @DisplayName("도서 수정 실패")
+    void updateBook_Fail() {
+        Long bookId = 9999L;
+        BookSaveRequest request = new BookSaveRequest();
+        given(bookRepository.findByIdWithRelations(bookId)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> bookService.updateBook(bookId, request))
+                .isInstanceOf(NotFoundBookException.class)
+                .hasMessageContaining("해당 도서를 찾을 수 없습니다 ID: " + bookId);
+
+        verify(bookFactory, never()).updateFields(any(), any());
+        verify(bookRelationService, never()).applyRelationsForUpdate(any(), any());
+        verify(bookSearchIndexService, never()).index(any());
+    }
+
+    @Test
+    @DisplayName("도서 삭제 성공 - 도서 미발견")
+    void deleteBook() {
+        Long bookId = 1L;
+        given(bookRepository.findById(bookId)).willReturn(Optional.of(bookA));
+
+        bookService.deleteBook(bookId);
+
+        verify(bookRepository, times(1)).delete(bookA);
+        verify(bookSearchIndexService, times(1)).deleteIndex(bookId);
+    }
+
+    @Test
+    @DisplayName("도서 삭제 실패 - 도서 미발견")
+    void deleteBook_Fail_NotFound() {
+        Long bookId = 999L;
+        given(bookRepository.findById(bookId)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> bookService.deleteBook(bookId))
+                .isInstanceOf(NotFoundBookException.class)
+                .hasMessageContaining("해당 도서를 찾을 수 없습니다 ID: " + bookId);
+
+        verify(bookRepository, never()).delete(any());
+        verify(bookSearchIndexService, never()).deleteIndex(anyLong());
+    }
+
+    @Test
+    void getBooks() {
+        BookSearchCondition condition = new BookSearchCondition();
+        Page<Book> bookPage = new PageImpl<>(List.of(bookA), pageable, 1);
+
+        BookListResponse mockResponse = BookListResponse.builder().id(bookA.getId()).title("Book A").build();
+        given(bookListResponseMapper.fromEntity(bookA)).willReturn(mockResponse);
+
+        given(bookRepository.findAll(pageable)).willReturn(bookPage);
+
+        Page<BookListResponse> responses = bookService.getBooks(condition, pageable);
+
+        assertThat(responses).hasSize(1);
+        verify(bookRepository, times(1)).findAll(pageable);
+    }
+
+    @Test
+    @DisplayName("도서 상세 조회 성공 - 로그인 유저, 좋아요 상태 포함")
+    void getBookDetail_Success() {
+        Long bookId = 1L;
+        Long userId = 100L;
+        long mockLikeCount = 5L;
+
+        given(bookRepository.findByIdWithRelations(bookId)).willReturn(Optional.of(bookA));
+        given(bookLikeRepository.countByBookId(bookId)).willReturn(mockLikeCount);
+        given(bookLikeRepository.existsByBookIdAndUserId(bookId, userId)).willReturn(true);
+
+        BookDetailResponse result = bookService.getBookDetail(bookId, userId);
+
+        assertThat(result).isNotNull();
+
+        assertThat(result.getLikedByCurrentUser()).isTrue();
+        assertThat(result.getLikeCount()).isEqualTo(mockLikeCount);
+        assertThat(result.getRating()).isEqualTo(5.0);
+        assertThat(result.getTitle()).isEqualTo("Book A");
+
+        assertThat(result.getCategories().get(0).getName()).isEqualTo("Test Category");
+        assertThat(result.getPriceStandard()).isEqualTo(10000L);
+
+        verify(bookRepository, times(1)).findByIdWithRelations(bookId);
+        verify(bookLikeRepository, times(1)).existsByBookIdAndUserId(bookId, userId);
+    }
+
+
+    @Test
+    @DisplayName("도서 상세 조회 성공 - 비로그인 유저")
+    void getBookDetail_Success_NotLoggedIn() {
+        Long bookId = 1L;
+
+        given(bookRepository.findByIdWithRelations(bookId)).willReturn(Optional.of(bookA));
+        given(bookLikeRepository.countByBookId(bookId)).willReturn(10L);
+
+        BookDetailResponse result = bookService.getBookDetail(bookId, null);
+
+        assertThat(result.getLikedByCurrentUser()).isNull();
+
+        verify(bookLikeRepository, times(0)).existsByBookIdAndUserId(anyLong(), anyLong());
+    }
+
+    @Test
+    @DisplayName("도서 상세 조회 실패 - 존재하지않은 도서 ID")
+    void getBook_Fail_Validation() {
+        Long bookId = 9999L;
+        Long userId = 1L;
+        given(bookRepository.findByIdWithRelations(bookId)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> bookService.getBookDetail(bookId, userId))
+                .isInstanceOf(NotFoundBookException.class)
+                .hasMessageContaining("해당 도서를 찾을 수 없습니다 ID: " + bookId);
+        verify(bookLikeRepository, never()).existsByBookIdAndUserId(anyLong(), anyLong());
+
+    }
+
+    @Test
+    @DisplayName("카테고리 조회 성공 - 트리 구조 변환 검증")
+    void getCategories_Success_TreeStructure() {
+        Category root = Category.builder().id(1L).categoryName("Root").build();
+        Category child1 = Category.builder().id(2L).categoryName("Child 1").parent(root).build();
+        Category child2 = Category.builder().id(3L).categoryName("Child 2").parent(root).build();
+
+        given(categoryRepository.findAll()).willReturn(List.of(root, child1, child2));
+
+        List<CategoryDto> result = bookService.getCategories();
+
+        assertThat(result).hasSize(1);
+        CategoryDto categoryDto = result.get(0);
+        assertThat(categoryDto.getName()).isEqualTo("Root");
+
+        assertThat(categoryDto.getParentId()).isNull();
+        assertThat(categoryDto.getChildren()).hasSize(2);
+        assertThat(categoryDto.getChildren()).extracting("name").containsExactlyInAnyOrder("Child 1", "Child 2");
+        verify(categoryRepository, times(1)).findAll();
+    }
+
+
+    @Test
+    @DisplayName("베스트 셀러 조회 성공")
+    void getBestsellers() {
+        String period = "DAILY";
+        Book bookB = Book.builder().id(2L).title("Book B").build();
+
+        given(orderServiceClient.getBestSellersBookIds(period)).willReturn(List.of(2L, 1L));
+        given(bookRepository.findAllById(anyList())).willReturn(List.of(bookA, bookB));
+
+        List<BookListResponse> responses = bookService.getBestsellers(period);
+
+        assertThat(responses).hasSize(2);
+        assertThat(responses.get(0).getId()).isEqualTo(2);
+        verify(orderServiceClient, times(1)).getBestSellersBookIds(period);
+    }
+
+    @Test
+    @DisplayName("베스트셀러 조회 - Order Service 장애 발생시 (예외전파 확인)")
+    void getBestsellers_Fail_OrderServiceError() {
+        String period = "DAILY";
+        given(orderServiceClient.getBestSellersBookIds(period))
+                .willThrow(new RuntimeException("Order Service Unavailable"));
+
+        assertThatThrownBy(() -> bookService.getBestsellers(period))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("Order Service Unavailable");
+
+        verify(bookRepository, never()).findAllById(any());
+    }
+
+    @Test
+    @DisplayName("신간 도서 조회 성공")
+    void getNewArrivals() {
+        Long categoryID = 5L;
+        Page<Book> page = new PageImpl<>(List.of(bookA), pageable, 1);
+
+        given(bookRepository.findNewArrivalsByCategoryId(eq(categoryID), any(Pageable.class))).willReturn(page);
+
+        Page<BookListResponse> responses = bookService.getNewArrivals(categoryID, pageable);
+
+        assertThat(responses).hasSize(1);
+        verify(bookRepository, times(1)).findNewArrivalsByCategoryId(categoryID, pageable);
+    }
+
+    @Test
+    @DisplayName("신간 도서 조회 실패 - DB 연결 오류 발생")
+    void getNewArrivals_Fail() {
+        Long categoryID = 5L;
+
+        given(bookRepository.findNewArrivalsByCategoryId(eq(categoryID), any(Pageable.class)))
+                .willThrow(new RuntimeException("DB 연결 불안정"));
+
+        assertThatThrownBy(() -> bookService.getNewArrivals(categoryID, pageable))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("DB 연결 불안정");
+        verify(bookRepository, times(1)).findNewArrivalsByCategoryId(categoryID, pageable);
+    }
+}


### PR DESCRIPTION
1. 베스트셀러 및 신간 조회 로직 구현
2. BookService 단윝 테스트 작성

## 🔀 PR 개요

사용자에게 트렌디한 도서 정보를 제공하기 위해 **베스트셀러(판매량순)**와 신간 도서(출간일순, 카테고리 필터링) 조회 로직을 BookService에 구현했습니다. 또한, 외부 서비스(Order-Service) 연동 및 복잡한 정렬 로직의 안정성을 보장하기 위해 Mockito 기반의 단위 테스트를 작성했습니다.


---

## 📄 변경 사항

어떤 부분이 수정/추가/삭제되었는지 구체적으로 기술해 주세요.

- [x] 새로운 기능 추가 (✨ Feature)
- [ ] 버그 수정 (🐞 BugFix)
- [x] 코드 리팩토링 (🔧 Refactor)
- [ ] 문서 수정 (📝 Docs)
- [x] 테스트 코드 추가 (🧪 Test)
- [ ] 배포 관련 (🚀 Deploy)
- [ ] 기타 설정 변경 (🧰 Setting)

### 1. 베스트셀러 조회 (getBestsellers)

Order-Service 연동: OrderServiceClient를 통해 판매량 상위 도서 ID 리스트를 조회.

순서 보장 로직: DB 조회 결과(findAllById)는 순서가 보장되지 않으므로, 애플리케이션 레벨에서 판매량 순서대로 도서 리스트를 재정렬하는 로직 구현.

캐싱 적용: 조회 빈도가 높고 연산 비용이 큰 로직이므로 Redis @Cacheable을 적용 (TTL: 12시간).

### 2. 신간 도서 조회 (getNewArrivals)

조건별 조회:

전체 신간: 출간일(publishDate) 내림차순 정렬.

카테고리별 신간: 특정 카테고리 내에서 출간일 내림차순 정렬 (JPQL findNewArrivalsByCategoryId 활용).

캐싱 적용: 카테고리 및 페이지 번호를 키로 하여 Redis 캐싱 적용.

### 3. 단위 테스트 작성 (BookServiceImplTest)

테스트 범위: BookService의 주요 비즈니스 로직 (CRUD, 큐레이션, 카테고리 조회).

검증 항목:

외부 의존성(Repository, Client, Redis) Mocking을 통한 격리 테스트.

베스트셀러 ID 리스트 순서대로 결과가 반환되는지 검증.

DTO 변환 시 연관 관계(이미지, 작가 등) NullPointerException 방지 및 데이터 매핑 정확성 검증.

실패 케이스(DB 장애, 빈 결과 등)에 대한 예외 처리 검증.

---

## 💡 변경 이유

외부 서비스(Order-Service) 연동 및 복잡한 정렬 로직의 안정성을 보장하기 위해 Mockito 기반의 단위 테스트를 작성했습니다.---

## 🧩 관련 이슈

closed #62 

---

## 🧪 테스트 방법

BookServiceImplTest의 모든 테스트 케이스(성공/실패 시나리오) 통과 (Pass)
