### PR TITLE
[Refactor] 도서 등록/수정 이미지 다중 처리 로직 변경 및 Redis 캐싱 직렬화 이슈 해결

### DIFF
--- a/http/req.http
+++ b/http/req.http
@@ -9,12 +9,14 @@
 #############################################
 
 ### 1) 도서 등록 (이미지 없이)
-POST http://localhost:8089/books
+POST http://localhost:8089/admin/books
 Content-Type: multipart/form-data; boundary=----FormBoundary
+X-User-Role: ROLE_BOOK_ADMIN
 
 ------FormBoundary
 Content-Disposition: form-data; name="book"
 Content-Type: application/json
+
 
 {
   "isbn": "9999999999",
@@ -58,8 +60,9 @@ GET http://localhost:8089/books/1
 
 
 ### 2) 도서 수정 (일부 필드만 변경)
-PUT http://localhost:8089/books/1
+PUT http://localhost:8089/admin/books/1
 Content-Type: multipart/form-data; boundary=WebAppBoundary
+X-User-Role: ROLE_BOOK_ADMIN
 
 --WebAppBoundary
 Content-Disposition: form-data; name="book"

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/Book2OnAndOnBookServiceApplication.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/Book2OnAndOnBookServiceApplication.java
@@ -4,12 +4,14 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableDiscoveryClient
 @EnableScheduling
 @EnableFeignClients
+@EnableSpringDataWebSupport(pageSerializationMode = EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO)
 public class Book2OnAndOnBookServiceApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/config/RedisConfig.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/config/RedisConfig.java
@@ -1,13 +1,24 @@
 package org.nhnacademy.book2onandonbookservice.config;
 
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.time.Duration;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -22,13 +33,25 @@ public class RedisConfig {
     @Value("${spring.cache.redis.key-prefix:book-service}")
     private String keyPrefix;
 
+
     @Bean //Redis가 캐시매니저인걸 EnableCaching으로 알려줌 그럼 Cacheable 어노테이션이 붙은 메서드가 호출되면 자동으로 Redis에 데이터를 저장하고 조회함
     public RedisCacheManager RedisCacheManager(RedisConnectionFactory connectionFactory) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        objectMapper.activateDefaultTyping(
+                LaissezFaireSubTypeValidator.instance,
+                ObjectMapper.DefaultTyping.NON_FINAL,
+                JsonTypeInfo.As.PROPERTY
+        );
+        objectMapper.addMixIn(PageImpl.class, PageImplMixin.class);
+
+        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
         RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
                 .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(
                         new StringRedisSerializer())) //키는 String 으로 직렬화
                 .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
-                        new GenericJackson2JsonRedisSerializer())) // 값은 Json으로 직렬화
+                        serializer)) // 값은 Json으로 직렬화
                 .computePrefixWith(cacheName -> keyPrefix + cacheName + "::") //모든 키 앞에 "book-service:"를 붙임
                 .entryTtl(Duration.ofDays(7)) // 캐시 유효시간 (TTL) 기본 7일 설정 (책 정보는 잘 안 바뀌기때문에 길게 잡는 것이 좋음)
                 .disableCachingNullValues();
@@ -38,5 +61,15 @@ public class RedisConfig {
                 .cacheDefaults(config)
                 .withInitialCacheConfigurations(cacheConfigurations)
                 .build();
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true, value = {"pageable"})
+    public abstract static class PageImplMixin<T> {
+        @JsonCreator
+        protected PageImplMixin(@JsonProperty("content") List<T> content,
+                                @JsonProperty("pageable") Pageable pageable,
+                                @JsonProperty("totalElements") long totalElements) {
+
+        }
     }
 }

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/controller/BookController.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/controller/BookController.java
@@ -79,6 +79,7 @@ public class BookController {
     public ResponseEntity<Page<BookListResponse>> getNewArrivals(
             @RequestParam(value = "categoryId", required = false) Long categoryId,
             @PageableDefault(sort = "publishDate", direction = Direction.DESC) Pageable pageable) {
+        log.info("신간도서 요청 들어옴");
         Page<BookListResponse> newArrivals = bookService.getNewArrivals(categoryId, pageable);
         return ResponseEntity.ok(newArrivals);
     }

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/dto/api/RestPage.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/dto/api/RestPage.java
@@ -1,0 +1,24 @@
+package org.nhnacademy.book2onandonbookservice.dto.api;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+@JsonIgnoreProperties(ignoreUnknown = true, value = {"pageable"})
+public class RestPage<T> extends PageImpl<T> {
+
+    @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+    public RestPage(@JsonProperty("content") List<T> content,
+                    @JsonProperty("number") int number,
+                    @JsonProperty("size") int size,
+                    @JsonProperty("totalElements") Long totalElements) {
+        super(content, PageRequest.of(number, size), totalElements);
+    }
+
+    public RestPage(org.springframework.data.domain.Page<T> page) {
+        super(page.getContent(), page.getPageable(), page.getTotalElements());
+    }
+}

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/dto/book/BookListResponse.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/dto/book/BookListResponse.java
@@ -3,14 +3,18 @@ package org.nhnacademy.book2onandonbookservice.dto.book;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.nhnacademy.book2onandonbookservice.entity.Book;
 import org.nhnacademy.book2onandonbookservice.entity.BookImage;
 
 // 도서 검색 시 여러 권을 리스트로 보여주는(조회하는) DTO
 @Getter
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class BookListResponse {
     private Long id;    // book_id
     private String title; // 도서 제목
@@ -20,6 +24,7 @@ public class BookListResponse {
     private Long priceSales; // 도서 판매가
     private Double rating; //평점
     private String imagePath;   // 도서 이미지
+
     private LocalDate publisherDate;
 
     private List<String> contributorNames;  // 기여자 정보

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/dto/book/BookUpdateRequest.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/dto/book/BookUpdateRequest.java
@@ -1,0 +1,59 @@
+package org.nhnacademy.book2onandonbookservice.dto.book;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.nhnacademy.book2onandonbookservice.domain.BookStatus;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class BookUpdateRequest {
+    // ISBN 검색
+    private String isbn;
+
+    // 도서 제목 관련
+    private String title; // 도서 제목
+    private String volume;  // 권 제목
+
+    // 기여자 정보
+    private String contributorName; // 기여자 이름
+
+    // 출판사
+    private String publisherName;   // 출판사 이름 -> 신규 출판사 생성 등록 시
+    private List<Long> publisherIds;    // 출판사 아이디 -> 이미 존재하는 출판사를 선택해서 매핑하는 경우
+
+    // 출판일
+    private LocalDate publishDate;
+
+    // 도서 가격
+    private Long priceStandard; // 도서 정가
+    private Long priceSales; // 도서 판매가
+
+    // 도서 재고 관련
+    private Integer stockCount; // 책 재고량
+    private BookStatus status; // 책 재고 상태
+
+    // 카테고리 및 태그, 포장 여부
+    private List<Long> categoryIds; // 카테고리
+    private Set<String> tagNames;  // 태그 리스트
+    private Boolean isWrapped;  // 포장 여부
+
+    // 이미지 url(경로)
+    @Setter
+    private String imagePath;
+
+    // 목차
+    private String chapter;
+
+    // -- 설명 - WYSIWYG 편집 후 결과 HTML -> Book.book_description에 그대로 저장
+    private String descriptionHtml;
+
+    private List<Long> deleteImageIds;
+}

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/repository/BookRepository.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/repository/BookRepository.java
@@ -32,7 +32,7 @@ public interface BookRepository extends JpaRepository<Book, Long> {
     Optional<Book> findByIdWithRelations(Long bookId);
 
     /// 신간 도서 조회용 (정렬 O)
-    @Query("SELECT DISTINCT b FROM Book b JOIN b.bookCategories bc WHERE bc.category.id IN :categoryIds ORDER BY b.publishDate DESC")
+    @Query("SELECT DISTINCT b FROM Book b JOIN b.bookCategories bc WHERE b.status='ON_SALE' AND bc.category.id IN :categoryIds ORDER BY b.publishDate DESC")
     Page<Book> findBooksByCategoryIdsSorted(@Param("categoryIds") List<Long> categoryIds, Pageable pageable);
 
     /// 검색 동기화용 (정렬 X)

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/service/book/BookFactory.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/service/book/BookFactory.java
@@ -1,8 +1,8 @@
 package org.nhnacademy.book2onandonbookservice.service.book;
 
 import lombok.RequiredArgsConstructor;
-import org.nhnacademy.book2onandonbookservice.domain.BookStatus;
 import org.nhnacademy.book2onandonbookservice.dto.book.BookSaveRequest;
+import org.nhnacademy.book2onandonbookservice.dto.book.BookUpdateRequest;
 import org.nhnacademy.book2onandonbookservice.entity.Book;
 import org.springframework.stereotype.Component;
 
@@ -16,7 +16,10 @@ public class BookFactory {
         Integer stockCount = (request.getStockCount() != null) ? request.getStockCount() : 0;
         boolean wrapped = Boolean.TRUE.equals(request.getIsWrapped());
 
-        return Book.builder().title(request.getTitle()).isbn(request.getIsbn()).volume(request.getVolume())
+        return Book.builder()
+                .title(request.getTitle())
+                .isbn(request.getIsbn())
+                .volume(request.getVolume())
                 .chapter(request.getChapter())
                 .description(request.getDescriptionHtml())
                 .priceStandard(priceStandard)
@@ -24,12 +27,11 @@ public class BookFactory {
                 .publishDate(request.getPublishDate())
                 .status(request.getStatus())
                 .stockCount(stockCount)
-                .status(BookStatus.ON_SALE) // 신규 등록은 기본 'ON_SALE'
                 .build();
     }
 
     // 도서 수정 시 단일 필드 업데이트
-    public void updateFields(Book book, BookSaveRequest req) {
+    public void updateFields(Book book, BookUpdateRequest req) {
 
         if (req.getTitle() != null) {
             book.setTitle(req.getTitle());

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/service/book/BookRelationService.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/service/book/BookRelationService.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.nhnacademy.book2onandonbookservice.dto.book.BookSaveRequest;
+import org.nhnacademy.book2onandonbookservice.dto.book.BookUpdateRequest;
 import org.nhnacademy.book2onandonbookservice.entity.Book;
 import org.nhnacademy.book2onandonbookservice.entity.BookCategory;
 import org.nhnacademy.book2onandonbookservice.entity.BookContributor;
@@ -173,7 +174,7 @@ public class BookRelationService {
     }
 
     /// 도서 수정 시 연관관계
-    public void applyRelationsForUpdate(Book book, BookSaveRequest request) {
+    public void applyRelationsForUpdate(Book book, BookUpdateRequest request) {
         // 카테고리: null 이 아니면 전체 교체
         if (request.getCategoryIds() != null) {
             setCategories(book, request.getCategoryIds());

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/service/book/BookService.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/service/book/BookService.java
@@ -7,17 +7,19 @@ import org.nhnacademy.book2onandonbookservice.dto.book.BookListResponse;
 import org.nhnacademy.book2onandonbookservice.dto.book.BookOrderResponse;
 import org.nhnacademy.book2onandonbookservice.dto.book.BookSaveRequest;
 import org.nhnacademy.book2onandonbookservice.dto.book.BookSearchCondition;
+import org.nhnacademy.book2onandonbookservice.dto.book.BookUpdateRequest;
 import org.nhnacademy.book2onandonbookservice.dto.book.StockRequest;
 import org.nhnacademy.book2onandonbookservice.dto.common.CategoryDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface BookService {
     // 도서 등록
-    Long createBook(BookSaveRequest request);
+    Long createBook(BookSaveRequest request, List<MultipartFile> images);
 
     // 도서 수정
-    void updateBook(Long bookId, BookSaveRequest request);
+    void updateBook(Long bookId, BookUpdateRequest request, List<MultipartFile> images);
 
     // 도서 삭제
     void deleteBook(Long bookId);

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/service/book/BookValidator.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/service/book/BookValidator.java
@@ -2,6 +2,7 @@ package org.nhnacademy.book2onandonbookservice.service.book;
 
 import java.util.List;
 import org.nhnacademy.book2onandonbookservice.dto.book.BookSaveRequest;
+import org.nhnacademy.book2onandonbookservice.dto.book.BookUpdateRequest;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -13,7 +14,7 @@ public class BookValidator {
     }
 
     // 도서 수정 검증 로직
-    public void validateForUpdate(BookSaveRequest request) {
+    public void validateForUpdate(BookUpdateRequest request) {
         validatePriceRangeIfPresent(request);
         validateCategoryCountIfPresent(request.getCategoryIds());
     }
@@ -64,7 +65,7 @@ public class BookValidator {
         }
     }
 
-    private void validatePriceRangeIfPresent(BookSaveRequest request) {
+    private void validatePriceRangeIfPresent(BookUpdateRequest request) {
         if (request.getPriceStandard() != null && request.getPriceStandard() < 0) {
             throw new IllegalArgumentException("정가는 0원 이상이어야 합니다.");
         }

--- a/src/test/java/org/nhnacademy/book2onandonbookservice/Book2OnAndOnBookServiceApplicationTests.java
+++ b/src/test/java/org/nhnacademy/book2onandonbookservice/Book2OnAndOnBookServiceApplicationTests.java
@@ -1,9 +1,7 @@
 package org.nhnacademy.book2onandonbookservice;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.mock;
 
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.nhnacademy.book2onandonbookservice.config.DataInitializer;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
@@ -81,57 +79,4 @@ class Book2OnAndOnBookServiceApplicationTests {
             return mock(ConnectionFactory.class);
         }
     }
-
-    @Test
-    @DisplayName("main 메서드 실행 테스트 (커버리지용)")
-    void main() {
-        assertDoesNotThrow(() -> {
-            Book2OnAndOnBookServiceApplication.main(new String[]{
-                    // 1. 인프라 (Eureka, Config Server) 연결 끄기
-                    "--spring.cloud.config.enabled=false",
-                    "--spring.config.import=optional:file:.",
-                    "--eureka.client.enabled=false",
-
-                    // 2. 데이터베이스 (MySQL 대신 H2 인메모리 DB 사용)
-                    // 실제 DB에 붙으면 데이터가 꼬이거나 연결 에러가 날 수 있으므로 H2를 씁니다.
-                    "--spring.datasource.url=jdbc:h2:mem:testdb;MODE=MySQL",
-                    "--spring.datasource.driver-class-name=org.h2.Driver",
-                    "--spring.datasource.username=sa",
-                    "--spring.datasource.password=",
-                    "--spring.jpa.hibernate.ddl-auto=create-drop",
-
-                    // 3. Redis (가짜 설정 - 실제 연결 안 해도 빈 생성만 되면 됨)
-                    "--spring.data.redis.host=localhost",
-                    "--spring.data.redis.port=6379",
-                    "--spring.data.redis.password=",
-                    "--spring.data.redis.repositories.enabled=false",
-
-                    // 4. Elasticsearch (가짜 설정)
-                    "--spring.elasticsearch.uris=http://localhost:9200",
-                    "--spring.elasticsearch.username=dummy",
-                    "--spring.elasticsearch.password=dummy",
-
-                    // 5. MinIO (가짜 설정 - @Value 주입 에러 방지용)
-                    "--minio.url=http://localhost:9000",
-                    "--minio.access-key=dummy-access",
-                    "--minio.secret-key=dummy-secret",
-                    "--minio.bucket-name=dummy-bucket",
-                    "--minio.folder.book=books",
-                    "--minio.folder.review=reviews",
-
-                    // 6. 외부 API 키 (가짜 설정 - 실제 호출 안 함)
-                    "--aladin.api.base-url=http://localhost/dummy-aladin",
-                    "--aladin.api-ttb-key=dummy-ttb-key",
-                    "--gemini.api.base-url=http://localhost/dummy-gemini",
-                    "--gemini.api-key=dummy-gemini-key",
-
-                    // 7. 스케줄러 비활성화 (테스트 중에 스케줄러 돌면 로그 지저분해지고 에러 가능성 있음)
-                    "--spring.task.scheduling.enabled=false",
-                    //8. RabbitMQ 리스너 자동 시작 비활성화
-                    "--spring.rabbitmq.listener.simple.auto-startup=false"
-            });
-
-        });
-    }
-
 }

--- a/src/test/java/org/nhnacademy/book2onandonbookservice/service/book/BookFactoryTest.java
+++ b/src/test/java/org/nhnacademy/book2onandonbookservice/service/book/BookFactoryTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.nhnacademy.book2onandonbookservice.domain.BookStatus;
 import org.nhnacademy.book2onandonbookservice.dto.book.BookSaveRequest;
+import org.nhnacademy.book2onandonbookservice.dto.book.BookUpdateRequest;
 import org.nhnacademy.book2onandonbookservice.entity.Book;
 
 class BookFactoryTest {
@@ -76,7 +77,7 @@ class BookFactoryTest {
                 .status(BookStatus.ON_SALE)
                 .build();
 
-        BookSaveRequest newBook = BookSaveRequest.builder()
+        BookUpdateRequest newBook = BookUpdateRequest.builder()
                 .title("신제목")
                 .priceStandard(2000L)
                 .status(BookStatus.ON_SALE)
@@ -100,7 +101,7 @@ class BookFactoryTest {
                 .isWrapped(true)
                 .build();
 
-        BookSaveRequest emptyRequest = BookSaveRequest.builder().build();
+        BookUpdateRequest emptyRequest = BookUpdateRequest.builder().build();
 
         bookFactory.updateFields(book, emptyRequest);
 
@@ -115,7 +116,7 @@ class BookFactoryTest {
     @DisplayName("updateFields: 모든 필드 업데이트 테스트")
     void updateFields_AllFields() {
         Book book = Book.builder().build();
-        BookSaveRequest request = BookSaveRequest.builder()
+        BookUpdateRequest request = BookUpdateRequest.builder()
                 .title("타타이이틀틀")
                 .volume("볼륨볼륨")
                 .chapter("채채텁텁텁!")

--- a/src/test/java/org/nhnacademy/book2onandonbookservice/service/book/BookRelationServiceTest.java
+++ b/src/test/java/org/nhnacademy/book2onandonbookservice/service/book/BookRelationServiceTest.java
@@ -21,6 +21,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.nhnacademy.book2onandonbookservice.dto.book.BookSaveRequest;
+import org.nhnacademy.book2onandonbookservice.dto.book.BookUpdateRequest;
 import org.nhnacademy.book2onandonbookservice.entity.Book;
 import org.nhnacademy.book2onandonbookservice.entity.BookCategory;
 import org.nhnacademy.book2onandonbookservice.entity.BookTag;
@@ -112,7 +113,7 @@ class BookRelationServiceTest {
         book.getBookCategories().add(bc1);
         book.getBookCategories().add(bc2);
 
-        BookSaveRequest request = BookSaveRequest.builder()
+        BookUpdateRequest request = BookUpdateRequest.builder()
                 .categoryIds(List.of(2L, 3L))
                 .build();
 
@@ -127,7 +128,7 @@ class BookRelationServiceTest {
         List<Long> currentIds = result.stream()
                 .map(bc -> bc.getCategory().getId())
                 .toList();
-        
+
         assertThat(currentIds).contains(2L, 3L).doesNotContain(1L);
     }
 
@@ -136,7 +137,7 @@ class BookRelationServiceTest {
     void applyRelationsForUpdate_NullFields() {
         book.getBookTags().add(mock(BookTag.class));
 
-        BookSaveRequest req = BookSaveRequest.builder()
+        BookUpdateRequest req = BookUpdateRequest.builder()
                 .categoryIds(null)
                 .tagNames(null)
                 .publisherIds(null)

--- a/src/test/java/org/nhnacademy/book2onandonbookservice/service/book/BookValidatorTest.java
+++ b/src/test/java/org/nhnacademy/book2onandonbookservice/service/book/BookValidatorTest.java
@@ -10,12 +10,23 @@ import java.util.stream.IntStream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.nhnacademy.book2onandonbookservice.dto.book.BookSaveRequest;
+import org.nhnacademy.book2onandonbookservice.dto.book.BookUpdateRequest;
 
 class BookValidatorTest {
     private final BookValidator validator = new BookValidator();
 
     private BookSaveRequest.BookSaveRequestBuilder createValidRequest() {
         return BookSaveRequest.builder()
+                .title("정상 제목")
+                .isbn("1234567890123")
+                .publishDate(LocalDate.now())
+                .priceStandard(10000L)
+                .priceSales(9000L)
+                .categoryIds(List.of(1L));
+    }
+
+    private BookUpdateRequest.BookUpdateRequestBuilder updateValidRequest() {
+        return BookUpdateRequest.builder()
                 .title("정상 제목")
                 .isbn("1234567890123")
                 .publishDate(LocalDate.now())
@@ -119,7 +130,7 @@ class BookValidatorTest {
     @Test
     @DisplayName("수정 성공: 값이 없거나 정상 범위 일때")
     void validateForUpdate_Success() {
-        BookSaveRequest request = BookSaveRequest.builder().build();
+        BookUpdateRequest request = BookUpdateRequest.builder().build();
 
         assertThatCode(() -> validator.validateForUpdate(request))
                 .doesNotThrowAnyException();
@@ -128,12 +139,12 @@ class BookValidatorTest {
     @Test
     @DisplayName("수정 실패: 정가,판매가가 음수인경우")
     void validateForCreate_InvalidPrice_Modify() {
-        BookSaveRequest request = createValidRequest().priceStandard(-1L).build();
+        BookUpdateRequest request = updateValidRequest().priceStandard(-1L).build();
         assertThatThrownBy(() -> validator.validateForUpdate(request))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("정가는 0원 이상");
 
-        BookSaveRequest request2 = createValidRequest().priceSales(-1L).build();
+        BookUpdateRequest request2 = updateValidRequest().priceSales(-1L).build();
         assertThatThrownBy(() -> validator.validateForUpdate(request2))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("판매가는 0원 이상");
@@ -142,7 +153,7 @@ class BookValidatorTest {
     @Test
     @DisplayName("수정 실패: 카테고리 리스트가 넘어왔는데 개수가 부적절한 경우")
     void validateForUpdate_InvalidCategory() {
-        BookSaveRequest request = BookSaveRequest.builder()
+        BookUpdateRequest request = BookUpdateRequest.builder()
                 .categoryIds(Collections.emptyList())
                 .build();
 
@@ -152,7 +163,7 @@ class BookValidatorTest {
 
         List<Long> manyCategories = IntStream.range(0, 11).mapToObj(Long::valueOf).toList();
 
-        BookSaveRequest req = BookSaveRequest.builder().categoryIds(manyCategories).build();
+        BookUpdateRequest req = BookUpdateRequest.builder().categoryIds(manyCategories).build();
 
         assertThatThrownBy(() -> validator.validateForUpdate(req)).isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("최대 10개");


### PR DESCRIPTION
## 🔀 PR 개요

도서 등록/수정 로직 개선: 단일 이미지 처리에서 List<MultipartFile>을 통한 다중 이미지 처리로 변경하고, 이미지 업로드 로직을 Controller에서 Service 계층으로 이동시켰습니다.

Redis 캐싱 오류 수정: PageImpl 객체 역직렬화 시 발생하는 SerializationException을 해결하기 위해 RedisConfig를 수정하고 Mixin을 적용했습니다.

---

## 📄 변경 사항

어떤 부분이 수정/추가/삭제되었는지 구체적으로 기술해 주세요.

- [ ] 새로운 기능 추가 (✨ Feature)
- [ ] 버그 수정 (🐞 BugFix)
- [x] 코드 리팩토링 (🔧 Refactor)
- [ ] 문서 수정 (📝 Docs)
- [x] 테스트 코드 추가 (🧪 Test)
- [ ] 배포 관련 (🚀 Deploy)
- [ ] 기타 설정 변경 (🧰 Setting)

---


1. Redis 설정 (RedisConfig)

ObjectMapper에 JavaTimeModule 및 activateDefaultTyping 설정 추가.

PageImpl 클래스의 기본 생성자 부재로 인한 역직렬화 실패를 해결하기 위해 PageImplMixin 추가 및 등록.

2. 도서 관리 로직 (BookService, BookController)

createBook, updateBook 메서드의 파라미터를 MultipartFile → List<MultipartFile>로 변경.

도서 수정 시: 기존 MinIO에 저장된 이미지를 삭제하고 새로운 이미지를 등록하는 로직 추가 (orphanRemoval 및 MinIO 삭제 연동).

도서 등록 시: 이미지 업로드 및 BookImage 엔티티 생성 로직을 Service 내부로 캡슐화.

3. DTO 수정 (BookListResponse)

Redis 역직렬화를 위해 @NoArgsConstructor (기본 생성자) 추가.

4. 테스트 코드 (BookAdminControllerTest)

변경된 서비스 시그니처(List<MultipartFile>)에 맞춰 Mock 객체 및 검증 로직 수정.



## 💡 변경 이유

신간도서가 캐시이유로 프론트와 API 통신문제가 있었습니다.
Book등록과 수정 이미지 로직이 리뷰 이미지 로직과 불일치하여 일치하도록 수정했습니다.

---

## 🧩 관련 이슈

#86 

---

## 🧪 테스트 방법

[x] Redis 캐시(book-service::newArrivals::null_0) 삭제 후 정상 동작 확인 완료.

[x] 도서 등록/수정 시 다중 이미지 처리가 정상적으로 수행되는지 확인.

[x] 기존 이미지가 수정 시 정상적으로 삭제되는지 확인.