### PR TITLE
feat: 리뷰생성시 user-service에 이미지포함여부 리퀘스트응답

### DIFF
--- a/src/main/java/org/nhnacademy/book2onandonbookservice/client/UserServiceClient.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/client/UserServiceClient.java
@@ -1,0 +1,15 @@
+package org.nhnacademy.book2onandonbookservice.client;
+
+import org.nhnacademy.book2onandonbookservice.dto.review.ReviewEventRequest;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(name = "USER-SERVICE")
+public interface UserServiceClient {
+
+    /// 리뷰 작성 이벤트 알림 (포인트 적립 등)
+    /// POST /internal/users/reviews/event
+    @PostMapping("/internal/users/reviews/event")
+    void notifyReviewCreated(@RequestBody ReviewEventRequest reviewEventRequest);
+}

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/controller/ReviewController.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/controller/ReviewController.java
@@ -45,11 +45,4 @@ public class ReviewController {
         return ResponseEntity.ok().build();
     }
 
-    //리뷰삭제
-    @DeleteMapping("/reviews/{reviewId}")
-    public ResponseEntity<Void> deleteReview(@PathVariable Long reviewId) {
-        reviewService.deleteReview(reviewId);
-        return ResponseEntity.noContent().build();
-    }
-
 }

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/dto/review/ReviewEventRequest.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/dto/review/ReviewEventRequest.java
@@ -1,0 +1,14 @@
+package org.nhnacademy.book2onandonbookservice.dto.review;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReviewEventRequest {
+    private Long userId;
+    private Long reviewId;
+    private boolean hasImage;
+}

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/entity/Review.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/entity/Review.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -23,7 +24,13 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Entity
-@Table(name = "Review")
+@Table(name = "Review",
+uniqueConstraints = {
+        @UniqueConstraint(
+                name="uk_review_book_user",
+                columnNames = {"book_id","user_id"}
+        )
+})
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/service/review/Impl/ReviewServiceImpl.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/service/review/Impl/ReviewServiceImpl.java
@@ -6,8 +6,10 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.nhnacademy.book2onandonbookservice.client.OrderServiceClient;
+import org.nhnacademy.book2onandonbookservice.client.UserServiceClient;
 import org.nhnacademy.book2onandonbookservice.dto.review.ReviewCreateRequest;
 import org.nhnacademy.book2onandonbookservice.dto.review.ReviewDto;
+import org.nhnacademy.book2onandonbookservice.dto.review.ReviewEventRequest;
 import org.nhnacademy.book2onandonbookservice.dto.review.ReviewUpdateRequest;
 import org.nhnacademy.book2onandonbookservice.entity.Book;
 import org.nhnacademy.book2onandonbookservice.entity.Review;
@@ -43,6 +45,8 @@ public class ReviewServiceImpl implements ReviewService {
     private final UserHeaderUtil util;
 
     private final StringRedisTemplate redisTemplate;
+
+    private final UserServiceClient userServiceClient;
 
 
     /// 리뷰생성
@@ -88,6 +92,8 @@ public class ReviewServiceImpl implements ReviewService {
                 .createdAt(LocalDateTime.now())
                 .build();
 
+        boolean hasImage = false;
+
         if (image != null && !image.isEmpty()) {
             for (MultipartFile file : image) {
                 if (!file.isEmpty()) {
@@ -100,6 +106,7 @@ public class ReviewServiceImpl implements ReviewService {
                             .build();
 
                     review.getImages().add(reviewImage);
+                    hasImage=true;
                 }
             }
         }
@@ -107,6 +114,15 @@ public class ReviewServiceImpl implements ReviewService {
         reviewRepository.save(review);
 
         updateBookRating(book);
+
+        try{
+            ReviewEventRequest eventRequest = new ReviewEventRequest(userId, review.getId(), hasImage);
+            userServiceClient.notifyReviewCreated(eventRequest);
+            log.info("User Service에 리뷰 등록 알림 전송 완료됨: userId:{}, hasImage={}", userId, hasImage);
+        } catch (Exception e) {
+            // userService가 죽어있을때 리뷰 등록 자체를 롤백 시키지 않고 로그만 찍을지, 아니면 리뷰 등록도 취소될지
+            log.error("User Service 리뷰 알림 전송 실패 (포인트 적립 누락 가능성): {}", e.getMessage());
+        }
 
         return review.getId();
     }
@@ -181,21 +197,7 @@ public class ReviewServiceImpl implements ReviewService {
         //3. 트랜잭션 종료 - JPA는 최초 상태와 현재 객체 상태를 비교해서 수정이 일어난게 보이면 바꼈다고 생각하고 자동반영
     }
 
-    /// 특정 리뷰 삭제
-    @Override
-    public void deleteReview(Long reviewId) {
-        Review review = reviewRepository.findById(reviewId).orElseThrow(() -> new NotFoundReviewException(reviewId));
 
-        Long currentId = util.getUserId();
-        if (!review.getUserId().equals(currentId)) {
-            throw new AccessDeniedException("본인의 리뷰만 삭제할 수 있습니다.");
-        }
-
-        Book book = review.getBook();
-        reviewRepository.delete(review); // entityManager.remove(review)가 실행됨
-        updateBookRating(book);
-        //트랜잭션이 끝날때 진짜 DELETE가 DB로 날아감
-    }
 
     /// 내부 로직 메서드
     //평점 업데이트 로직

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/service/review/ReviewService.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/service/review/ReviewService.java
@@ -18,6 +18,4 @@ public interface ReviewService {
     Page<ReviewDto> getReviewListByUserId(Long userId, Pageable pageable);
 
     void updateReview(Long reviewId, ReviewUpdateRequest request, List<MultipartFile> images);
-
-    void deleteReview(Long reviewId);
 }

--- a/src/test/java/org/nhnacademy/book2onandonbookservice/controller/ReviewControllerTest.java
+++ b/src/test/java/org/nhnacademy/book2onandonbookservice/controller/ReviewControllerTest.java
@@ -170,17 +170,4 @@ class ReviewControllerTest {
 
         verify(reviewService).updateReview(eq(reviewDtos.getId()), any(ReviewUpdateRequest.class), any());
     }
-
-    @Test
-    @DisplayName("리뷰 삭제 성공")
-    void deleteReview() throws Exception {
-        Long reviewId = 3L;
-        willDoNothing().given(reviewService).deleteReview(reviewId);
-
-        mockMvc.perform(delete("/books/reviews/{reviewId}", reviewId))
-                .andDo(print())
-                .andExpect(status().isNoContent());
-
-        verify(reviewService).deleteReview(reviewId);
-    }
 }

--- a/src/test/java/org/nhnacademy/book2onandonbookservice/service/review/Impl/ReviewServiceImplTest.java
+++ b/src/test/java/org/nhnacademy/book2onandonbookservice/service/review/Impl/ReviewServiceImplTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -21,12 +22,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.nhnacademy.book2onandonbookservice.client.OrderServiceClient;
+import org.nhnacademy.book2onandonbookservice.client.UserServiceClient;
 import org.nhnacademy.book2onandonbookservice.dto.review.ReviewCreateRequest;
 import org.nhnacademy.book2onandonbookservice.dto.review.ReviewDto;
+import org.nhnacademy.book2onandonbookservice.dto.review.ReviewEventRequest;
 import org.nhnacademy.book2onandonbookservice.dto.review.ReviewUpdateRequest;
 import org.nhnacademy.book2onandonbookservice.entity.Book;
 import org.nhnacademy.book2onandonbookservice.entity.Review;
@@ -67,6 +71,9 @@ class ReviewServiceImplTest {
     @Mock
     ValueOperations<String, String> valueOperations;
 
+    @Mock
+    UserServiceClient userServiceClient;
+
     private Book book;
     private Long bookId = 1L;
     private Long userId = 100L;
@@ -97,6 +104,11 @@ class ReviewServiceImplTest {
 
         verify(reviewRepository, times(1)).save(any(Review.class));
         verify(orderServiceClient, never()).hasPurchased(any(), any());
+
+        ArgumentCaptor<ReviewEventRequest> captor = ArgumentCaptor.forClass(ReviewEventRequest.class);
+        verify(userServiceClient).notifyReviewCreated(captor.capture());
+
+        assertThat(captor.getValue().isHasImage()).isFalse();
     }
 
     @Test
@@ -121,6 +133,26 @@ class ReviewServiceImplTest {
         // Redis에 캐시 저장했는지 검증 (90일)
         verify(valueOperations, times(1)).set(eq(redisKey), eq("Y"), any(Duration.class));
     }
+
+    @Test
+    @DisplayName("리뷰 생성 성공 - User Service 알림 전송 실패해도 리뷰는 정상 등록되어야 함 (Resilience)")
+    void createReview_Success_EvenIfUserClientFails() {
+        ReviewCreateRequest request = ReviewCreateRequest.builder().title("안전한 리뷰").score(5).content("내용").build();
+        String redisKey = "purchase:" + userId + ":" + bookId;
+
+        given(bookRepository.findById(bookId)).willReturn(Optional.of(book));
+        given(util.getUserId()).willReturn(userId);
+        given(redisTemplate.hasKey(redisKey)).willReturn(true);
+
+        doThrow(new RuntimeException("User Service Down")).when(userServiceClient).notifyReviewCreated(any());
+
+        reviewService.createReview(bookId, request, Collections.emptyList());
+
+        verify(reviewRepository, times(1)).save(any(Review.class));
+        verify(userServiceClient, times(1)).notifyReviewCreated(any());
+    }
+
+
 
     @Test
     @DisplayName("리뷰 생성 실패 - 구매 이력 없음 (Redis X, Feign False)")
@@ -190,6 +222,12 @@ class ReviewServiceImplTest {
 
         verify(imageUploadService, times(1)).uploadReviewImage(mockFile);
         verify(reviewRepository, times(1)).save(any(Review.class));
+        ArgumentCaptor<ReviewEventRequest> captor = ArgumentCaptor.forClass(ReviewEventRequest.class);
+        verify(userServiceClient, times(1)).notifyReviewCreated(captor.capture());
+
+        ReviewEventRequest sentRequest = captor.getValue();
+        assertThat(sentRequest.getUserId()).isEqualTo(userId);
+        assertThat(sentRequest.isHasImage()).isTrue();
     }
 
 
@@ -319,56 +357,5 @@ class ReviewServiceImplTest {
         assertThatThrownBy(() -> reviewService.updateReview(reviewId, request, null))
                 .isInstanceOf(NotFoundReviewException.class);
     }
-
-
-    @Test
-    @DisplayName("리뷰 삭제 성공")
-    void deleteReview_Success() {
-        Long reviewId = 10L;
-        Review review = Review.builder().id(reviewId).userId(userId).book(book).build();
-
-        given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
-        given(util.getUserId()).willReturn(userId);
-
-        reviewService.deleteReview(reviewId);
-
-        verify(reviewRepository, times(1)).delete(review);
-        // 평점 업데이트 호출 확인
-        verify(reviewRepository, times(1)).getAverageScoreByBook(book);
-    }
-
-    @Test
-    @DisplayName("리뷰 삭제 실패 - 작성자 불일치")
-    void deleteReview_Fail_AccessDenied() {
-        Long reviewId = 10L;
-        Long otherUser = 999L;
-        Review review = Review.builder().id(reviewId).userId(userId).build();
-
-        given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
-        given(util.getUserId()).willReturn(otherUser);
-
-        assertThatThrownBy(() -> reviewService.deleteReview(reviewId))
-                .isInstanceOf(AccessDeniedException.class);
-    }
-
-    @Test
-    @DisplayName("리뷰 삭제하고 평점 업데이트 만약 남은 리뷰가 없을때 평균이 null, 그럼 0.0으로 초기화 되는지")
-    void deleteReview_UpdateRating() {
-        Long reviewId = 10L;
-        book.updateRating(4.5);
-
-        Review review = Review.builder().id(reviewId).userId(userId).book(book).build();
-
-        given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
-        given(util.getUserId()).willReturn(userId);
-
-        given(reviewRepository.getAverageScoreByBook(book)).willReturn(null);
-
-        reviewService.deleteReview(reviewId);
-
-        verify(reviewRepository).delete(review);
-        assertThat(book.getRating()).isEqualTo(0.0);
-    }
-
 
 }


### PR DESCRIPTION
## 🔀 PR 개요

User-service에서 리뷰의 이미지 여부에 따른 포인트지급을 위한 true/false값을 반환해주는 로직을 생성했습니다.

---

## 📄 변경 사항

어떤 부분이 수정/추가/삭제되었는지 구체적으로 기술해 주세요.

- [x] 새로운 기능 추가 (✨ Feature)
- [ ] 버그 수정 (🐞 BugFix)
- [x] 코드 리팩토링 (🔧 Refactor)
- [ ] 문서 수정 (📝 Docs)
- [x] 테스트 코드 추가 (🧪 Test)
- [ ] 배포 관련 (🚀 Deploy)
- [ ] 기타 설정 변경 (🧰 Setting)

- ReviewEventRequest dto생성
- createReveiw 메스드 끝단에 생성이 올바르게 완료됐을 경우 User-service에게 요청을 보냅니다.
- createReveiw 테스트 코드에 userClient에게 올바른 요청이 갔는지 검증하는 로직을 구현했습니다.

---

## 💡 변경 이유

User-service에서 리뷰 이미지에 따른 포인트 지급 분기를 돕는 로직입니다.
이미지 여부에 따라 포인트가 다르게 지급되기때문에 필요한 부분입니다.

---

## 🧩 관련 이슈

- Closes #102 

---

## 🧪 테스트 방법

test/java/service/review.imple/ReviewServiceImplTest 로직을 실행시켜봅니다.
