### PR TITLE
feautre: cart 응답 response 및 전체도서 count 권한 추가

### DIFF
--- a/src/main/java/org/nhnacademy/book2onandonbookservice/client/AladinApiClient.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/client/AladinApiClient.java
@@ -6,6 +6,7 @@ import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.nhnacademy.book2onandonbookservice.dto.api.AladinApiResponse;
+import org.nhnacademy.book2onandonbookservice.exception.AladinApiException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.ResponseEntity;
@@ -56,7 +57,7 @@ public class AladinApiClient {
             }
             if (rawJson.contains("errorCode") || rawJson.contains("errorMessage")) {
                 log.error("알라딘 API 에러 응답 감지 (ISBN: {}): {}", isbn, rawJson);
-                throw new RuntimeException("Aladin API Error Response: " + rawJson);
+                throw new AladinApiException("Aladin API Error Response: " + rawJson);
             }
 
             AladinApiResponse response = objectMapper.readValue(rawJson, AladinApiResponse.class);

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/client/AladinCreateClient.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/client/AladinCreateClient.java
@@ -6,6 +6,7 @@ import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.nhnacademy.book2onandonbookservice.dto.api.AladinApiResponse;
+import org.nhnacademy.book2onandonbookservice.exception.AladinApiException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.ResponseEntity;
@@ -53,7 +54,7 @@ public class AladinCreateClient {
             }
             if (rawJson.contains("errorCode") || rawJson.contains("errorMessage")) {
                 log.error("알라딘 API 에러 응답 감지 (ISBN: {}): {}", isbn, rawJson);
-                throw new RuntimeException("Aladin API Error Response: " + rawJson);
+                throw new AladinApiException("Aladin API Error Response: " + rawJson);
             }
 
             AladinApiResponse response = objectMapper.readValue(rawJson, AladinApiResponse.class);

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/controller/BookAdminController.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/controller/BookAdminController.java
@@ -100,7 +100,7 @@ public class BookAdminController {
     }
 
     /// 도서 개수 반환
-    @AuthCheck(Role.BOOK_ADMIN)
+    @AuthCheck({Role.BOOK_ADMIN, Role.COUPON_ADMIN, Role.MEMBER_ADMIN, Role.ORDER_ADMIN})
     @GetMapping("/total-count")
     public ResponseEntity<Long> getBookCount(){
         long count = bookService.getBookCount();

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/controller/OrderController.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/controller/OrderController.java
@@ -2,8 +2,10 @@ package org.nhnacademy.book2onandonbookservice.controller;
 
 
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.nhnacademy.book2onandonbookservice.dto.book.BookOrderResponse;
+import org.nhnacademy.book2onandonbookservice.dto.book.CartResponse;
 import org.nhnacademy.book2onandonbookservice.dto.book.StockRequest;
 import org.nhnacademy.book2onandonbookservice.service.book.BookService;
 import org.nhnacademy.book2onandonbookservice.util.UserHeaderUtil;
@@ -44,5 +46,10 @@ public class OrderController {
         return ResponseEntity.ok().build();
     }
 
+    @PostMapping("/bulk")
+    public ResponseEntity<Map<Long, CartResponse>> getBookSnapshots(@RequestBody List<Long> bookIds){
+        Map<Long, CartResponse> result = bookService.getBookSnapshots(bookIds);
+        return ResponseEntity.ok(result);
+    }
 
 }

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/dto/book/CartResponse.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/dto/book/CartResponse.java
@@ -4,7 +4,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import org.nhnacademy.book2onandonbookservice.domain.BookStatus;
-import org.nhnacademy.book2onandonbookservice.dto.common.CategoryDto;
 import org.nhnacademy.book2onandonbookservice.entity.Book;
 import org.nhnacademy.book2onandonbookservice.entity.BookImage;
 import org.springframework.util.StringUtils;
@@ -12,18 +11,18 @@ import org.springframework.util.StringUtils;
 @Getter
 @Setter
 @Builder
-public class BookOrderResponse {
+public class CartResponse {
     private Long bookId;
     private String title;
-    private Long priceSales;
-    private String imageUrl;
-    private boolean isWrapped;
-    private Integer stockCount;
-    private BookStatus status;
-    private Long categoryId;
+    private String thumbnailUrl;
+    private int originalPrice;
+    private int salePrice;
+    private int stockCount;
+    private boolean saleEnded; // 판매 종료 여부
+    private boolean deleted; // 관리자에 의해 삭제된 상품
 
 
-    public static BookOrderResponse from(Book book) {
+    public static CartResponse from(Book book) {
         String resolvedImage = book.getThumbnail();
 
         if (!StringUtils.hasText(resolvedImage)) {
@@ -34,16 +33,18 @@ public class BookOrderResponse {
                     .orElse("/images/no-image.png");
         }
 
+        boolean isSaleEnded = book.getStatus().equals(BookStatus.SOLD_OUT) || book.getStatus().equals(BookStatus.OUT_OF_STOCK);
+        boolean isDeleted = book.getStatus().equals(BookStatus.BOOK_DELETED);
 
-        return BookOrderResponse.builder()
+        return CartResponse.builder()
                 .bookId(book.getId())
                 .title(book.getTitle())
-                .priceSales(book.getPriceSales())
-                .imageUrl(resolvedImage)
-                .isWrapped(book.getIsWrapped())
+                .salePrice(book.getPriceSales().intValue())
+                .originalPrice(book.getPriceStandard().intValue())
+                .thumbnailUrl(resolvedImage)
                 .stockCount(book.getStockCount())
-                .status(book.getStatus())
-                .categoryId(book.getCategory().getId())
+                .saleEnded(isSaleEnded)
+                .deleted(isDeleted)
                 .build();
     }
 }

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/exception/AladinApiException.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/exception/AladinApiException.java
@@ -1,0 +1,7 @@
+package org.nhnacademy.book2onandonbookservice.exception;
+
+public class AladinApiException extends RuntimeException {
+    public AladinApiException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package org.nhnacademy.book2onandonbookservice.exception;
 
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.extern.slf4j.Slf4j;
 import org.nhnacademy.book2onandonbookservice.dto.error.ErrorResponse;
@@ -61,6 +62,9 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(response, HttpStatus.CONFLICT);
     }
 
+    /**
+     * [403 Forbidden] 접근 거부 예외
+     */
     @ExceptionHandler(AccessDeniedException.class)
     public ResponseEntity<ErrorResponse> handleAccessDeniedException(AccessDeniedException e) {
         ErrorResponse response = new ErrorResponse(
@@ -97,4 +101,20 @@ public class GlobalExceptionHandler {
         );
         return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
     }
+
+    /**
+     * [502 Bad Gateway] 외부 API 통신 문제
+     */
+    @ExceptionHandler(AladinApiException.class)
+    public ResponseEntity<ErrorResponse> handleApiException(AladinApiException ae){
+        ErrorResponse response = new ErrorResponse(
+                LocalDateTime.now(),
+                HttpStatus.BAD_GATEWAY.value(),
+                "EXTERNAL_API_ERROR",
+                "API 통신 중 오류가 발생했습니다."
+        );
+        return new ResponseEntity<>(response, HttpStatus.BAD_GATEWAY);
+
+    }
+
 }

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/service/book/BookService.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/service/book/BookService.java
@@ -1,6 +1,7 @@
 package org.nhnacademy.book2onandonbookservice.service.book;
 
 import java.util.List;
+import java.util.Map;
 import org.nhnacademy.book2onandonbookservice.domain.BookStatus;
 import org.nhnacademy.book2onandonbookservice.dto.book.BookDetailResponse;
 import org.nhnacademy.book2onandonbookservice.dto.book.BookListResponse;
@@ -8,6 +9,7 @@ import org.nhnacademy.book2onandonbookservice.dto.book.BookOrderResponse;
 import org.nhnacademy.book2onandonbookservice.dto.book.BookSaveRequest;
 import org.nhnacademy.book2onandonbookservice.dto.book.BookSearchCondition;
 import org.nhnacademy.book2onandonbookservice.dto.book.BookUpdateRequest;
+import org.nhnacademy.book2onandonbookservice.dto.book.CartResponse;
 import org.nhnacademy.book2onandonbookservice.dto.book.StockRequest;
 import org.nhnacademy.book2onandonbookservice.dto.common.CategoryDto;
 import org.springframework.data.domain.Page;
@@ -69,4 +71,7 @@ public interface BookService {
 
     //최근 본 상품 guest -> 로그인 했을 때 merge
     void mergeRecentViews(String guestId, Long userId);
+
+    //cart 응답 (bookIdList를 받아오면 Id에 맞는 책 정보를 넘김)
+    Map<Long, CartResponse> getBookSnapshots(List<Long> bookIds);
 }

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/service/book/BookServiceImpl.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/service/book/BookServiceImpl.java
@@ -20,6 +20,7 @@ import org.nhnacademy.book2onandonbookservice.dto.book.BookOrderResponse;
 import org.nhnacademy.book2onandonbookservice.dto.book.BookSaveRequest;
 import org.nhnacademy.book2onandonbookservice.dto.book.BookSearchCondition;
 import org.nhnacademy.book2onandonbookservice.dto.book.BookUpdateRequest;
+import org.nhnacademy.book2onandonbookservice.dto.book.CartResponse;
 import org.nhnacademy.book2onandonbookservice.dto.book.StockRequest;
 import org.nhnacademy.book2onandonbookservice.dto.common.CategoryDto;
 import org.nhnacademy.book2onandonbookservice.entity.Book;
@@ -471,6 +472,18 @@ public class BookServiceImpl implements BookService {
             return;
         }
         bookHistoryService.mergeHistory(guestId, userId);
+    }
+
+    @Override
+    public Map<Long, CartResponse> getBookSnapshots(List<Long> bookIds) {
+        List<Book> books = bookRepository.findAllById(bookIds);
+
+        return books.stream()
+                .map(CartResponse::from)
+                .collect(Collectors.toMap(
+                        CartResponse::getBookId,
+                        CartResponse -> CartResponse
+                ));
     }
 
     ///    내부 로직


### PR DESCRIPTION
## 🔀 PR 개요

- 장바구니(Cart) 서비스/프론트엔드에서 도서 정보를 일괄적으로 조회할 수 있는 bulk API를 구현했습니다.

- 장바구니 표시에 최적화된 CartResponse DTO를 추가하여 썸네일, 품절 여부, 삭제 여부 등을 클라이언트가 처리하기 쉽게 가공하여 반환합니다.

- 관리자 페이지 대시보드 등에서 사용할 total-count API의 접근 권한을 다른 관리자 역할까지 확장했습니다.

---

## 📄 변경 사항

어떤 부분이 수정/추가/삭제되었는지 구체적으로 기술해 주세요.

- [x] 새로운 기능 추가 (✨ Feature)
- [ ] 버그 수정 (🐞 BugFix)
- [ ] 코드 리팩토링 (🔧 Refactor)
- [ ] 문서 수정 (📝 Docs)
- [ ] 테스트 코드 추가 (🧪 Test)
- [ ] 배포 관련 (🚀 Deploy)
- [ ] 기타 설정 변경 (🧰 Setting)

### 1. 도서 일괄 조회 API 추가 (POST /books/bulk)

- 기능: List<Long> bookIds를 요청 본문으로 받아, 해당 도서들의 스냅샷 정보를 Map<Long, CartResponse> 형태로 반환합니다.

- 용도: 장바구니에 담긴 여러 도서의 최신 가격, 재고, 상태 정보를 한 번의 요청으로 가져오기 위함입니다.

### 2. CartResponse DTO 구현

- 썸네일 처리 로직 개선: thumbnail 컬럼이 비어있을 경우, BookImage 리스트의 첫 번째 이미지를 사용하거나 기본 이미지(/images/no-image.png)를 반환하도록 로직을 강화했습니다.

- 상태 플래그 추가:

saleEnded: SOLD_OUT 또는 OUT_OF_STOCK 상태일 때 true 반환.
deleted: BOOK_DELETED 상태일 때 true 반환 (장바구니에서 삭제된 상품 표시용).

### 3. 전체 도서 개수 조회 권한 확대 (GET /total-count)

- 기존: BOOK_ADMIN만 접근 가능.

- 변경: BOOK_ADMIN, COUPON_ADMIN, MEMBER_ADMIN, ORDER_ADMIN 등 모든 관리자 역할이 대시보드 통계 등을 위해 접근할 수 있도록 @AuthCheck 어노테이션을 수정했습니다.

---

## 💡 변경 이유

### 1. 장바구니 데이터 동기화 및 네트워크 효율성 개선

- 문제점: 기존에는 장바구니에 담긴 도서들의 최신 정보(가격 변동, 품절 여부, 삭제 여부)를 확인하기 위해, 프론트엔드에서 도서 ID마다 개별 API를 호출해야 했습니다. 이는 장바구니 상품이 많을수록 네트워크 요청이 급증하는 비효율을 초래했습니다.

- 해결: 도서 ID 목록을 받아 한 번의 요청으로 필요한 스냅샷 데이터를 반환하는 bulk API를 구현하여 네트워크 부하를 줄이고 로딩 속도를 개선했습니다.

### 2. 프론트엔드 렌더링 로직 단순화 (CartResponse)

- 문제점: 도서의 썸네일이 없거나, 이미지가 리스트로 관리되는 구조 때문에 프론트엔드에서 "대표 이미지"를 선정하는 로직이 복잡했습니다. 또한, '판매 종료'나 '삭제됨' 상태를 프론트에서 일일이 Enum 상태값과 비교해야 했습니다.

- 해결: CartResponse DTO 내부에서 썸네일 추출 로직(Null 체크 및 대체 이미지)과 상태 판단 로직(saleEnded, deleted)을 처리하여, 프론트엔드는 true/false 값만 보고 바로 UI를 렌더링할 수 있도록 개선했습니다.

### 3. 관리자 대시보드 통계 접근 권한 현실화

- 문제점: '전체 도서 개수(total-count)' API가 BOOK_ADMIN 권한으로만 제한되어 있어, 다른 관리자(주문, 회원, 쿠폰 관리자)가 통합 대시보드에 접속했을 때 해당 위젯에서 403 Forbidden 에러가 발생하는 문제가 있었습니다.

- 해결: 대시보드 통계 데이터는 민감한 수정 권한이 아니므로, 모든 관리자 역할(COUPON_ADMIN, MEMBER_ADMIN 등)이 조회할 수 있도록 권한을 확장했습니다.

---

## 🧪 테스트 방법

- [x] 장바구니 조회 시 삭제된 도서나 품절된 도서의 상태값이 올바르게 반환되는지 확인했나요?

- [x] 썸네일이 없는 도서의 경우 대체 로직이 정상 동작하나요?

- [x] 다른 관리자 계정(예: MEMBER_ADMIN)으로 /total-count 호출 시 403 에러 없이 정상 응답하나요?
