### PR TITLE
[Feat/Fix] 도서 이미지 마이그레이션 스케줄러 동시성 이슈 해결 및 분산 락(ShedLock) 적용, 도서 수정/등록/삭제 개선 , 리뷰 등록/수정개선

### DIFF
--- a/src/main/java/org/nhnacademy/book2onandonbookservice/aop/AuthCheckAspect.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/aop/AuthCheckAspect.java
@@ -3,6 +3,7 @@ package org.nhnacademy.book2onandonbookservice.aop;
 
 import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
 import org.nhnacademy.book2onandonbookservice.annotation.AuthCheck;
@@ -14,6 +15,7 @@ import org.springframework.stereotype.Component;
 @Aspect
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class AuthCheckAspect {
 
     private final UserHeaderUtil userHeaderUtil;
@@ -25,12 +27,27 @@ public class AuthCheckAspect {
         if (userRoleStr == null || userRoleStr.isEmpty()) {
             throw new AccessDeniedException("권한 정보가 없습니다. (로그인 필요)");
         }
+        String[] userRoles = userRoleStr.split(",");
+        boolean isSuperAdmin = Arrays.stream(userRoles)
+                .map(String::trim)
+                .anyMatch(role -> Role.SUPER_ADMIN.getRoleName().equals(role));
+
+        if (isSuperAdmin) {
+            return;
+        }
         if (Role.SUPER_ADMIN.getRoleName().equals(userRoleStr)) {
             return;
         }
-        boolean hasPermission = Arrays.stream(authCheck.value())
-                .anyMatch(allowedRole -> allowedRole.getRoleName().equals(userRoleStr));
+        boolean hasPermission = Arrays.stream(authCheck.value()) // 필요한 권한 목록 순회
+                .anyMatch(requiredRole ->
+                        Arrays.stream(userRoles) // 사용자의 보유 권한 목록 순회
+                                .map(String::trim)
+                                .anyMatch(userRole -> userRole.equals(requiredRole.getRoleName()))
+                );
+
         if (!hasPermission) {
+            // 디버깅을 위해 로그를 남겨두면 좋습니다.
+            log.error("권한 거부됨. 사용자 보유 권한: [{}], 필요 권한: [{}]", userRoleStr, Arrays.toString(authCheck.value()));
             throw new AccessDeniedException("해당 리소스에 접근할 권한이 없습니다.");
         }
     }

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/config/DataInitializer.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/config/DataInitializer.java
@@ -164,10 +164,6 @@ public class DataInitializer implements ApplicationRunner {
     private void saveBatchSafe(List<Book> batch) {
         try {
             bookBatchService.saveBooksInBatch(batch);
-            Thread.sleep(1500);
-        } catch (InterruptedException e) {
-            log.error("배치 휴식 중 인터럽트 발생", e);
-            Thread.currentThread().interrupt();
         } catch (Exception e) {
             log.error("배치 저장 중 오류 발생 (Batch Size: {}): {}", batch.size(), e.getMessage());
         }
@@ -193,10 +189,6 @@ public class DataInitializer implements ApplicationRunner {
             return null;
         }
         String rawImageUrl = safeGet(row, h, "IMAGE_URL");
-        String minioImageUrl = null;
-        if(StringUtils.hasText(rawImageUrl)){
-            minioImageUrl = imageUploadService.uploadImageFromUrl(rawImageUrl);
-        }
 
         // 출판사 처리 (캐시 조회 -> 없으면 저장 후 캐시 등록)
         String pubName = safeGet(row, h, "PUBLISHER_NM");
@@ -221,7 +213,7 @@ public class DataInitializer implements ApplicationRunner {
                 .isWrapped(true) // 포장 가능 여부
                 .status(BookStatus.ON_SALE)
                 .volume(safeGet(row, h, "VLM_NM")) //volume
-                .thumbnail(minioImageUrl)
+                .thumbnail(rawImageUrl)
                 .build();
 
         //연관관계 설정: 출판사
@@ -235,10 +227,10 @@ public class DataInitializer implements ApplicationRunner {
         if (StringUtils.hasText(rawAuthorStr)) {
             parseAndAddContributors(book, rawAuthorStr);
         }
-        if (StringUtils.hasText(minioImageUrl)) {
+        if (StringUtils.hasText(rawImageUrl)) {
             book.getImages().add(BookImage.builder()
                     .book(book)
-                    .imagePath(minioImageUrl)
+                    .imagePath(rawImageUrl)
                     .isThumbnail(true)
                     .build());
         }

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/controller/BookController.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/controller/BookController.java
@@ -57,6 +57,7 @@ public class BookController {
         Long userId = util.getUserId();
         String guestId = util.getGuestId();
         BookDetailResponse response = bookService.getBookDetail(bookId, userId, guestId);
+
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/controller/ReviewController.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/controller/ReviewController.java
@@ -2,12 +2,16 @@ package org.nhnacademy.book2onandonbookservice.controller;
 
 
 import jakarta.validation.Valid;
+import jakarta.ws.rs.Path;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.nhnacademy.book2onandonbookservice.annotation.AuthCheck;
 import org.nhnacademy.book2onandonbookservice.domain.Role;
 import org.nhnacademy.book2onandonbookservice.dto.review.ReviewCreateRequest;
+import org.nhnacademy.book2onandonbookservice.dto.review.ReviewDto;
 import org.nhnacademy.book2onandonbookservice.dto.review.ReviewUpdateRequest;
+import org.nhnacademy.book2onandonbookservice.entity.Review;
 import org.nhnacademy.book2onandonbookservice.service.review.PurchaseVerificationService;
 import org.nhnacademy.book2onandonbookservice.service.review.ReviewService;
 import org.nhnacademy.book2onandonbookservice.util.UserHeaderUtil;
@@ -25,6 +29,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
+@Slf4j
 @RequestMapping("/books")
 public class ReviewController {
 
@@ -32,18 +37,22 @@ public class ReviewController {
     private final PurchaseVerificationService purchaseVerificationService;
     private final UserHeaderUtil util;
     //리뷰생성
-    @AuthCheck(Role.USER)
     @PostMapping(value = "/{bookId}/reviews", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<Long> createReview(@PathVariable Long bookId,
                                              @RequestPart(value = "request") @Valid ReviewCreateRequest request,
                                              @RequestPart(value = "images", required = false) List<MultipartFile> images) {
         Long reviewId = reviewService.createReview(bookId, request, images);
+
         return ResponseEntity.status(HttpStatus.CREATED).body(reviewId);
+    }
+
+    @GetMapping("/review/{reviewId}")
+    public ResponseEntity<ReviewDto> getReview(@PathVariable Long reviewId){
+        return ResponseEntity.ok().body(reviewService.getReview(reviewId));
     }
 
 
     //리뷰수정
-    @AuthCheck(Role.USER)
     @PutMapping(value = "/reviews/{reviewId}")
     public ResponseEntity<Void> updateReview(@PathVariable Long reviewId,
                                              @RequestPart(value = "request") @Valid ReviewUpdateRequest request,
@@ -53,7 +62,6 @@ public class ReviewController {
     }
 
     //리뷰 작성 가능 자격 확인 API
-    @AuthCheck(Role.USER)
     @GetMapping("/{bookId}/reviews/eligibility")
     public ResponseEntity<Boolean> checkReviewEligibility(@PathVariable Long bookId){
         Long userId = util.getUserId();
@@ -62,5 +70,7 @@ public class ReviewController {
 
         return ResponseEntity.ok(isEligible);
     }
+
+
 
 }

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/controller/UserController.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/controller/UserController.java
@@ -5,6 +5,7 @@ import org.nhnacademy.book2onandonbookservice.annotation.AuthCheck;
 import org.nhnacademy.book2onandonbookservice.domain.Role;
 import org.nhnacademy.book2onandonbookservice.dto.book.MyLikedBookResponse;
 import org.nhnacademy.book2onandonbookservice.dto.review.ReviewDto;
+import org.nhnacademy.book2onandonbookservice.repository.BookRepository;
 import org.nhnacademy.book2onandonbookservice.service.book.BookLikeService;
 import org.nhnacademy.book2onandonbookservice.service.review.ReviewService;
 import org.nhnacademy.book2onandonbookservice.util.UserHeaderUtil;
@@ -23,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/internal/users")
 public class UserController {
     private final ReviewService reviewService;
+    private final BookRepository bookRepository;
     private final BookLikeService bookLikeService;
     private final UserHeaderUtil util;
 

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/domain/BookStatus.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/domain/BookStatus.java
@@ -1,9 +1,9 @@
 package org.nhnacademy.book2onandonbookservice.domain;
 
 public enum BookStatus {
-    OUT_OF_STOCK,   //품절(입고 예정 없음)
-    SOLD_OUT,   //일시 품절(재입고 예정)
-    BOOK_DELETED,   //삭제, 노출 중단
+    OUT_OF_STOCK,   //품절(입고 예정 없음) 북 리스트에서 비활성화 처리
+    SOLD_OUT,   //일시 품절(재입고 예정) 북 디테일까진 들어가지는데 구매하기 버튼 비활성화 처리
+    BOOK_DELETED,   //삭제, 노출 중단 아예안보임
     ON_SALE //판매중
     ;
 

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/dto/book/BookListResponse.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/dto/book/BookListResponse.java
@@ -9,6 +9,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.nhnacademy.book2onandonbookservice.domain.BookStatus;
 import org.nhnacademy.book2onandonbookservice.entity.Book;
 import org.nhnacademy.book2onandonbookservice.entity.BookImage;
 import org.nhnacademy.book2onandonbookservice.entity.Category;
@@ -28,6 +29,7 @@ public class BookListResponse {
     private Long priceStandard; // 도서 정가
     private Long priceSales; // 도서 판매가
     private Double rating; //평점
+    private BookStatus status;
 
     private LocalDate publisherDate;
     private List<String> contributorNames;  // 기여자 정보
@@ -63,6 +65,7 @@ public class BookListResponse {
                 .rating(book.getRating())
                 .publisherDate(book.getPublishDate())
                 .thumbnail(resolvedImage)
+                .status(book.getStatus())
                 .contributorNames(book.getBookContributors().stream()
                         .map(bc -> bc.getContributor().getContributorName())
                         .toList()

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/dto/review/ReviewCreateRequest.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/dto/review/ReviewCreateRequest.java
@@ -3,6 +3,8 @@ package org.nhnacademy.book2onandonbookservice.dto.review;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,4 +30,6 @@ public class ReviewCreateRequest {
     @Max(value = 5, message = "별점은 최대 5점입니다.")
     private Integer score;  // 평가 점수
 
+    private String writerName;
+    private LocalDate writerDate;
 }

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/dto/review/ReviewDto.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/dto/review/ReviewDto.java
@@ -17,11 +17,14 @@ public class ReviewDto {
     private Long id;    // 리뷰 아이디
     private Long bookId;    // 도서 아이디
     private Long userId;    // 회원 아이디
+    private String bookTitle;
+
+    private String writerName;
 
     private String title;   // 리뷰 제목
     private String content; // 리뷰 내용
     private Integer score;  // 평가 점수
-    private LocalDate createdAt;    // 리뷰 생성 일시
+    private LocalDate writerDate;    // 리뷰 생성 일시
 
 
     private List<ReviewImageDto> images;    // 이미지 경로 저장 리스트
@@ -38,14 +41,19 @@ public class ReviewDto {
                         .build()) // 이미지 객체에서 경로만 쏙 뺌
                 .toList();
 
+
+
         // 빌더로 DTO 생성 후 반환
         return ReviewDto.builder()
                 .id(review.getId())
+                .bookId(review.getBook().getId())
                 .userId(review.getUserId()) // 닉네임이 필요하면 User-Service 통신 필요 (일단 ID로)
                 .title(review.getTitle())
                 .content(review.getContent())
+                .writerName(review.getWriterName())
+                .bookTitle(review.getBook().getTitle())
                 .score(review.getScore())
-                .createdAt(review.getCreatedAt().toLocalDate())
+                .writerDate(review.getCreatedAt())
                 .images(images)
                 .build();
     }

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/dto/review/ReviewUpdateRequest.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/dto/review/ReviewUpdateRequest.java
@@ -3,6 +3,7 @@ package org.nhnacademy.book2onandonbookservice.dto.review;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -27,6 +28,9 @@ public class ReviewUpdateRequest {
     @Min(value = 1, message = "별점은 최소 1점입니다.")
     @Max(value = 5, message = "별점은 최대 5점입니다.")
     private Integer score;  // 평가 점수
+
+    private String writerName;
+    private LocalDate writerDate;
 
     private List<Long> deleteImageIds;
 }

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/entity/Review.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/entity/Review.java
@@ -14,6 +14,7 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -62,7 +63,7 @@ public class Review {
     // 리뷰 작성일
     @Column(name = "review_date", nullable = false)
     @Setter
-    private LocalDateTime createdAt;
+    private LocalDate createdAt;
 
     // 도서 아이디
     @ManyToOne(fetch = FetchType.LAZY)
@@ -74,6 +75,10 @@ public class Review {
     @Column(name = "user_id", nullable = false)
     @Setter
     private Long userId;
+
+    @Column(name = "writer_name", nullable = false)
+    private String writerName; // 작성자 이름 저장
+
 
     // 리뷰 이미지 매핑
     @OneToMany(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/repository/BookRepository.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/repository/BookRepository.java
@@ -98,6 +98,8 @@ public interface BookRepository extends JpaRepository<Book, Long> {
     @Query("SELECT b.stockCount From Book b where b.id = :id")
     Integer findStockCountById(@Param("id") Long id);
 
+    List<Book> findTop100ByThumbnailIsNotNullAndThumbnailNotLike(String myDomain);
+
     interface BookIdAndIsbn {
         Long getId();
 

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/scheduler/ImageMigrationScheduler.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/scheduler/ImageMigrationScheduler.java
@@ -1,0 +1,122 @@
+package org.nhnacademy.book2onandonbookservice.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.nhnacademy.book2onandonbookservice.entity.Book;
+import org.nhnacademy.book2onandonbookservice.entity.BookImage;
+import org.nhnacademy.book2onandonbookservice.repository.BookRepository;
+import org.nhnacademy.book2onandonbookservice.service.image.ImageUploadService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ImageMigrationScheduler {
+
+    private final BookRepository bookRepository;
+    private final ImageUploadService imageUploadService;
+    private final PlatformTransactionManager transactionManager;
+
+    @Value("${minio.public-url}")
+    private String minioDomain;
+
+    private final Executor taskExecutor = Executors.newFixedThreadPool(10);
+
+    @Scheduled(fixedDelay = 3000)
+    @SchedulerLock(name="ImageMigrationTask", lockAtLeastFor = "PT2S", lockAtMostFor = "PT10S")
+    public void migrateImagesChunk() {
+
+        List<Book> targets = bookRepository.findTop100ByThumbnailIsNotNullAndThumbnailNotLike("%" + minioDomain + "%");
+
+        if (targets.isEmpty()) {
+             // log.info("이미지 마이그레이션 대상 없음 (모두 완료됨)");
+            return;
+        }
+
+        List<Long> targetIds = targets.stream().map(Book::getId).toList();
+
+        log.info("[Scheduler] 이미지 변환 배치 시작: {}건 (Redis Lock 적용됨)", targetIds.size());
+        long start = System.currentTimeMillis();
+
+        // 2. ID를 기반으로 각 스레드에 작업 할당
+        List<CompletableFuture<Void>> futures = targetIds.stream()
+                .map(bookId -> CompletableFuture.runAsync(() -> processSingleBookInTransaction(bookId), taskExecutor))
+                .toList();
+
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+
+        long end = System.currentTimeMillis();
+        log.info("배치 {}건 처리 완료. 소요시간: {}ms", targetIds.size(), (end - start));
+    }
+
+    private void processSingleBook(Book book) {
+        String originalUrl = book.getThumbnail();
+        
+        if (originalUrl.contains(minioDomain)) {
+            return;
+        }
+
+        try {
+            String newUrl = imageUploadService.uploadImageFromUrl(originalUrl);
+
+            if (newUrl != null) {
+                book.setThumbnail(newUrl);
+
+                boolean imageFound = false;
+
+                for (BookImage image : book.getImages()) {
+                    if (image.isThumbnail()) {
+                        image.setImagePath(newUrl);
+                        imageFound = true;
+                    }
+                }
+
+                if (!imageFound) {
+                    book.getImages().add(BookImage.builder()
+                            .book(book)
+                            .imagePath(newUrl)
+                            .isThumbnail(true)
+                            .build());
+                }
+
+            } else {
+                log.warn("이미지 다운 실패 -> NULL 처리: {}", book.getIsbn());
+                book.setThumbnail(null);
+            }
+        } catch (Exception e) {
+            log.error("이미지 변환 중 에러 발생: ISBN {}", book.getIsbn(), e);
+        }
+    }
+    private void processSingleBookInTransaction(Long bookId) {
+        TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+
+        // 트랜잭션 시작
+        transactionTemplate.execute(status -> {
+            try {
+                // 1. 이 스레드만의 영속성 컨텍스트에서 다시 조회
+                Book book = bookRepository.findById(bookId).orElse(null);
+                if (book == null) return null;
+
+                processSingleBook(book);
+
+                // 더티 체킹(Dirty Checking)에 의해 변경사항 자동 감지되어 커밋됨
+                return null;
+            } catch (Exception e) {
+                log.error("이미지 변환 트랜잭션 실패: BookID {}", bookId, e);
+                status.setRollbackOnly(); // 에러 발생 시 롤백
+                return null;
+            }
+        });
+    }
+}

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/service/book/BookRelationService.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/service/book/BookRelationService.java
@@ -108,17 +108,29 @@ public class BookRelationService {
     }
 
     /// 태그 설정: 태그명이 없으면 무시, 없는 태그 -> 신규 생성
-    private void setTags(Book book, Set<String> tagNames) {
-        if (tagNames == null || tagNames.isEmpty()) {
-            return;
-        }
+    private void setTags(Book book, Set<String> tagNamesInput) {
+        Set<String> newTagNames = (tagNamesInput == null) ? new HashSet<>() :
+                tagNamesInput.stream()
+                        .filter(StringUtils::isNotBlank)
+                        .map(String::trim)
+                        .collect(Collectors.toSet());
 
-        for (String tagName : tagNames.stream().distinct().toList()) {
-            if (StringUtils.isNotBlank(tagName)) {
+        book.getBookTags().removeIf(bookTag ->
+                !newTagNames.contains(bookTag.getTag().getTagName().trim())
+        );
+
+        Set<String> existingTagNames = book.getBookTags().stream()
+                .map(bt -> bt.getTag().getTagName().trim())
+                .collect(Collectors.toSet());
+
+        for (String tagName : newTagNames) {
+            if (!existingTagNames.contains(tagName)) {
+
                 Tag tag = tagRepository.findByTagName(tagName)
                         .orElseGet(() -> tagRepository.save(Tag.builder()
                                 .tagName(tagName)
                                 .build()));
+
                 BookTagPK pk = new BookTagPK(book.getId(), tag.getId());
                 BookTag bookTag = BookTag.builder()
                         .pk(pk)
@@ -158,22 +170,82 @@ public class BookRelationService {
 
         // 태그: null 이 아니면 전체 교체
         if (request.getTagNames() != null) {
-            book.getBookTags().clear();
             setTags(book, request.getTagNames());
         }
 
         // 출판사: ID 목록 또는 이름이 들어온 경우 전체 교체
         if (request.getPublisherIds() != null || StringUtils.isNotBlank(request.getPublisherName())) {
-            book.getBookPublishers().clear();
-            setPublishers(book, request.getPublisherIds(), request.getPublisherName());
+            updatePublishersSafely(book, request.getPublisherIds(), request.getPublisherName());
         }
 
         // 기여자: null 이면 건드리지 않고, 빈 문자열이면 모두 제거
         if (request.getContributorName() != null) {
-            book.getBookContributors().clear();
-            setContributors(book, request.getContributorName());
+            updateContributorsSafely(book, request.getContributorName());
         }
 
+    }
+
+    private void updatePublishersSafely(Book book, List<Long> publisherIds, String publisherName) {
+        Set<Publisher> targetPublishers = new HashSet<>();
+
+        if (publisherIds != null && !publisherIds.isEmpty()) {
+            targetPublishers.addAll(publisherRepository.findAllById(publisherIds));
+        }
+
+        if (StringUtils.isNotBlank(publisherName)) {
+            Publisher namedPublisher = publisherRepository.findByPublisherName(publisherName)
+                    .orElseGet(() -> publisherRepository.save(
+                            Publisher.builder().publisherName(publisherName).build()
+                    ));
+            targetPublishers.add(namedPublisher);
+        }
+
+        Set<Long> targetIds = targetPublishers.stream().map(Publisher::getId).collect(Collectors.toSet());
+        book.getBookPublishers().removeIf(bp -> !targetIds.contains(bp.getPublisher().getId()));
+
+        for (Publisher publisher : targetPublishers) {
+            if (!book.hasPublisher(publisher)) {
+                book.addPublisher(publisher);
+            }
+        }
+    }
+
+    private void updateContributorsSafely(Book book, String contributorName) {
+        if (contributorName.trim().isEmpty()) {
+            book.getBookContributors().clear();
+            return;
+        }
+
+        Set<String> targetNames = Arrays.stream(contributorName.split(","))
+                .map(String::trim)
+                .filter(this::notBlank)
+                .collect(Collectors.toSet());
+
+        Set<Contributor> targetContributors = new HashSet<>();
+        for (String name : targetNames) {
+            Contributor contributor = contributorRepository.findByContributorName(name)
+                    .orElseGet(() -> contributorRepository.save(
+                            Contributor.builder().contributorName(name).build()
+                    ));
+            targetContributors.add(contributor);
+        }
+
+        book.getBookContributors().removeIf(bc ->
+                !targetNames.contains(bc.getContributor().getContributorName()));
+
+        for (Contributor contributor : targetContributors) {
+            boolean exists = book.getBookContributors().stream()
+                    .anyMatch(bc -> bc.getContributor().getId().equals(contributor.getId()));
+
+            if (!exists) {
+                BookContributor newContributor = BookContributor.builder()
+                        .book(book)
+                        .contributor(contributor)
+                        .roleType("지은이")
+                        .build();
+                book.getBookContributors().add(newContributor);
+            }
+        }
     }
 
     /// 공통 문자열 유틸

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/service/book/BookServiceImpl.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/service/book/BookServiceImpl.java
@@ -263,10 +263,7 @@ public class BookServiceImpl implements BookService {
         long likeCount = bookLikeRepository.countByBookId(bookId);
 
         // 비로그인: null, 로그인: true/false
-        Boolean likedByCurrentUser = null;
-        if (userId != null) {
-            likedByCurrentUser = bookLikeRepository.existsByBookIdAndUserId(bookId, userId);
-        }
+        Boolean likedByCurrentUser = (userId != null) ? bookLikeRepository.existsByBookIdAndUserId(bookId, userId) : null;
 
         return BookDetailResponse.from(book, likeCount, likedByCurrentUser);
     }

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/service/book/BookServiceImpl.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/service/book/BookServiceImpl.java
@@ -110,6 +110,8 @@ public class BookServiceImpl implements BookService {
                 .orElseThrow(() -> new NotFoundBookException(bookId));
         int oldStock = book.getStockCount();
         // 1. 단순 필드 업데이트
+        log.debug("도서수정 목차: {}", request.getChapter());
+        log.debug("도서수정 설명: {}", request.getDescriptionHtml());
         bookFactory.updateFields(book, request);
 
         //재고 변경 감지 및 Redis 동기화

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/service/enrichment/CategoryEnrichmentService.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/service/enrichment/CategoryEnrichmentService.java
@@ -1,6 +1,7 @@
 package org.nhnacademy.book2onandonbookservice.service.enrichment;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.nhnacademy.book2onandonbookservice.dto.api.AladinApiResponse;
 import org.nhnacademy.book2onandonbookservice.entity.Book;
 import org.nhnacademy.book2onandonbookservice.entity.Category;
@@ -11,6 +12,7 @@ import org.springframework.util.StringUtils;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class CategoryEnrichmentService {
 
     private final CategoryRepository categoryRepository;
@@ -19,7 +21,9 @@ public class CategoryEnrichmentService {
         String categoryPath = aladinData.getCategoryName();
 
         if(!StringUtils.hasText(categoryPath)){
-            throw new CategoryResolveException("알라딘 카테고리 정보 없음");
+            log.warn("알라딘 카테고리 정보 없음. isbn={}, title={}",
+                    book.getIsbn(), book.getTitle());
+            return;
         }
 
         Category leaf = resolveCategoryTree(categoryPath);

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/service/image/ImageUploadService.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/service/image/ImageUploadService.java
@@ -134,7 +134,7 @@ public class ImageUploadService {
             try {
                 return uploadInternal(imageUrl, "image/jpeg");
             } catch (RejectedExecutionException | InterruptedIOException ie) {
-                // ★ 핵심 수정: 시스템 종료나 쓰레드 풀 종료로 인한 에러는 ERROR 로그 안 찍음
+                // 시스템 종료나 쓰레드 풀 종료로 인한 에러는 ERROR 로그 안 찍음
                 log.warn("이미지 업로드 중단 (시스템 종료 또는 재시작 감지): {}", imageUrl);
                 return null;
             } catch (java.io.FileNotFoundException fe) {

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/service/review/Impl/ReviewServiceImpl.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/service/review/Impl/ReviewServiceImpl.java
@@ -59,6 +59,7 @@ public class ReviewServiceImpl implements ReviewService {
         if (!isPurchased) {
             throw new BookNotPurchasedException();
         }
+
         //리뷰가 이미 존재하면 커스텀 예외에서 리뷰가 이미 존재 메시지를 뱉음
         if (reviewRepository.existsByBookIdAndUserId(bookId, userId)) {
             throw new ReviewAlreadyExistsException();

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/service/review/Impl/ReviewServiceImpl.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/service/review/Impl/ReviewServiceImpl.java
@@ -1,6 +1,7 @@
 package org.nhnacademy.book2onandonbookservice.service.review.Impl;
 
 import java.time.Duration;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -51,7 +52,7 @@ public class ReviewServiceImpl implements ReviewService {
         Book book = bookRepository.findById(bookId).orElseThrow(() -> new NotFoundBookException(bookId));
         Long userId = util.getUserId();
 
-        //1. 구매 검증 (Redis 조회 -> 없으면 API 호출 -> 캐싱까지 자동처리
+//        1. 구매 검증 (Redis 조회 -> 없으면 API 호출 -> 캐싱까지 자동처리
         boolean isPurchased = purchaseVerificationService.verifyPurchase(userId,bookId );
 
         // 구매가 false면 커스텀 예외에서 배송 후 리뷰작성 메시지를 뱉음
@@ -70,7 +71,8 @@ public class ReviewServiceImpl implements ReviewService {
                 .title(req.getTitle())
                 .content(req.getContent())
                 .score(req.getScore())
-                .createdAt(LocalDateTime.now())
+                .writerName(req.getWriterName())
+                .createdAt(LocalDate.now())
                 .build();
 
         boolean hasImage = false;
@@ -123,6 +125,13 @@ public class ReviewServiceImpl implements ReviewService {
     public Page<ReviewDto> getReviewListByUserId(Long userId, Pageable pageable) {
         Page<Review> reviewPage = reviewRepository.findAllByUserId(userId, pageable);
         return reviewPage.map(ReviewDto::from);
+    }
+
+    @Override
+    public ReviewDto getReview(Long reviewId) {
+        Review review = reviewRepository.findById(reviewId).orElseThrow(()-> new NotFoundReviewException(reviewId));
+
+        return ReviewDto.from(review);
     }
 
     /*

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/service/review/ReviewService.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/service/review/ReviewService.java
@@ -4,17 +4,23 @@ import java.util.List;
 import org.nhnacademy.book2onandonbookservice.dto.review.ReviewCreateRequest;
 import org.nhnacademy.book2onandonbookservice.dto.review.ReviewDto;
 import org.nhnacademy.book2onandonbookservice.dto.review.ReviewUpdateRequest;
+import org.nhnacademy.book2onandonbookservice.entity.Review;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface ReviewService {
     Long createReview(Long bookId, ReviewCreateRequest req, List<MultipartFile> image);
 
+    ReviewDto getReview(Long reviewId);
+
     /// 특정 책에 대한 리뷰목록
     Page<ReviewDto> getReviewListByBookId(Long bookId, Pageable pageable);
 
     /// 특정 유저에 대한 리뷰목록
+    @Query(value = "SELECT r FROM Review r JOIN FETCH r.book WHERE r.userId = :userId",
+            countQuery = "SELECT COUNT(r) FROM Review r WHERE r.userId = :userId")
     Page<ReviewDto> getReviewListByUserId(Long userId, Pageable pageable);
 
     void updateReview(Long reviewId, ReviewUpdateRequest request, List<MultipartFile> images);

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/service/search/BookSearchDocument.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/service/search/BookSearchDocument.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import java.time.LocalDate;
 import java.util.List;
@@ -12,6 +13,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.nhnacademy.book2onandonbookservice.domain.BookStatus;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
@@ -115,6 +117,9 @@ public class BookSearchDocument {
 
     @Field(type = FieldType.Double)
     private Double reviewRating; // 평점
+
+    @Field(type = FieldType.Text)
+    private BookStatus status;
 
     // --- Ollama (BGE-M3) 1024차원 벡터 ---
     @Field(type = FieldType.Dense_Vector, dims = 1024)

--- a/src/main/java/org/nhnacademy/book2onandonbookservice/service/search/BookSearchIndexService.java
+++ b/src/main/java/org/nhnacademy/book2onandonbookservice/service/search/BookSearchIndexService.java
@@ -111,6 +111,7 @@ public class BookSearchIndexService {
                 .publishDate(book.getPublishDate())
                 .priceStandard(book.getPriceStandard())
                 .priceSales(book.getPriceSales())
+                .status(book.getStatus())
                 // 정렬/가중치 필드 (엔티티에 없으면 0으로 초기화하거나 계산 로직 필요)
                 .popularity(popularity) // 좋아요 순
                 .reviewCount(reviewCount) //리뷰 수

--- a/src/test/java/org/nhnacademy/book2onandonbookservice/dto/book/BookDetailResponseTest.java
+++ b/src/test/java/org/nhnacademy/book2onandonbookservice/dto/book/BookDetailResponseTest.java
@@ -67,7 +67,7 @@ class BookDetailResponseTest {
         BookImage img = mock(BookImage.class); when(img.getImagePath()).thenReturn("img.jpg");
         when(book.getImages()).thenReturn(Set.of(img));
 
-        Review r1 = mock(Review.class); when(r1.getId()).thenReturn(1L); when(r1.getCreatedAt()).thenReturn(LocalDateTime.now());
+        Review r1 = mock(Review.class); when(r1.getId()).thenReturn(1L); when(r1.getCreatedAt()).thenReturn(LocalDate.now());
         when(book.getReviews()).thenReturn(Set.of(r1));
 
         BookDetailResponse response = BookDetailResponse.from(book, 100L, true);
@@ -129,7 +129,7 @@ class BookDetailResponseTest {
         when(book.getBookTags()).thenReturn(Collections.emptySet());
         when(book.getBookPublishers()).thenReturn(Collections.emptySet());
 
-        LocalDateTime now = LocalDateTime.now();
+        LocalDate now = LocalDate.now();
         Review r1 = mock(Review.class); when(r1.getId()).thenReturn(1L); when(r1.getCreatedAt()).thenReturn(now.minusDays(5));
         Review r2 = mock(Review.class); when(r2.getId()).thenReturn(2L); when(r2.getCreatedAt()).thenReturn(now.minusDays(1)); // 1등
         Review r3 = mock(Review.class); when(r3.getId()).thenReturn(3L); when(r3.getCreatedAt()).thenReturn(now.minusDays(2)); // 2등

--- a/src/test/java/org/nhnacademy/book2onandonbookservice/dto/book/BookListResponseTest.java
+++ b/src/test/java/org/nhnacademy/book2onandonbookservice/dto/book/BookListResponseTest.java
@@ -2,6 +2,7 @@ package org.nhnacademy.book2onandonbookservice.dto.book;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.nhnacademy.book2onandonbookservice.domain.BookStatus;
 import org.nhnacademy.book2onandonbookservice.entity.*;
 
 import java.time.LocalDate;
@@ -138,7 +139,7 @@ class BookListResponseTest {
         assertThat(dto.getTitle()).isEqualTo("Title");
 
         BookListResponse allArgs = new BookListResponse(
-                1L, "Title", "Vol", 1000L, 900L, 4.5, LocalDate.now(),
+                1L, "Title", "Vol", 1000L, 900L, 4.5, BookStatus.BOOK_DELETED, LocalDate.now(),
                 List.of("C"), List.of("P"), List.of("T"), List.of("Cat"), "thumb.jpg"
         );
         assertThat(allArgs.getId()).isEqualTo(1L);

--- a/src/test/java/org/nhnacademy/book2onandonbookservice/dto/review/ReviewDtoTest.java
+++ b/src/test/java/org/nhnacademy/book2onandonbookservice/dto/review/ReviewDtoTest.java
@@ -23,7 +23,7 @@ class ReviewDtoTest {
         Review review = mock(Review.class);
         ReviewImage reviewImage = mock(ReviewImage.class);
 
-        LocalDateTime now = LocalDateTime.now();
+        LocalDate now = LocalDate.now();
 
         when(review.getId()).thenReturn(1L);
         when(review.getUserId()).thenReturn(100L);
@@ -43,7 +43,7 @@ class ReviewDtoTest {
         assertThat(result.getTitle()).isEqualTo("Review Title");
         assertThat(result.getContent()).isEqualTo("Content");
         assertThat(result.getScore()).isEqualTo(5);
-        assertThat(result.getCreatedAt()).isEqualTo(now.toLocalDate());
+        assertThat(result.getWriterDate()).isEqualTo(now);
 
         assertThat(result.getImages()).hasSize(1);
         assertThat(result.getImages().get(0).getId()).isEqualTo(10L);
@@ -54,7 +54,7 @@ class ReviewDtoTest {
     @DisplayName("성공: 이미지가 없는 Review 엔티티 변환")
     void from_Success_NoImages() {
         Review review = mock(Review.class);
-        LocalDateTime now = LocalDateTime.now();
+        LocalDate now = LocalDate.now();
 
         when(review.getId()).thenReturn(2L);
         when(review.getUserId()).thenReturn(200L);
@@ -84,7 +84,7 @@ class ReviewDtoTest {
         assertThat(noArgs).isNotNull();
 
         ReviewDto allArgs = new ReviewDto(
-                1L, 2L, 3L, "Title", "Content", 5, LocalDate.now(), Collections.emptyList()
+                1L, 2L, 3L, "BookTitle","nickname","Title", "Content", 5, LocalDate.now(), Collections.emptyList()
         );
         assertThat(allArgs.getId()).isEqualTo(1L);
         assertThat(allArgs.getBookId()).isEqualTo(2L);

--- a/src/test/java/org/nhnacademy/book2onandonbookservice/service/review/Impl/ReviewServiceImplTest.java
+++ b/src/test/java/org/nhnacademy/book2onandonbookservice/service/review/Impl/ReviewServiceImplTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -198,7 +199,7 @@ class ReviewServiceImplTest {
         // Given
         Pageable pageable = PageRequest.of(0, 10);
         Review review = Review.builder().id(1L).book(book).userId(userId).title("R1").content("C1")
-                .createdAt(LocalDateTime.now()).score(5).build();
+                .createdAt(LocalDate.now()).score(5).build();
         Page<Review> page = new PageImpl<>(List.of(review));
 
         given(bookRepository.findById(bookId)).willReturn(Optional.of(book));
@@ -230,7 +231,7 @@ class ReviewServiceImplTest {
         // Given
         Pageable pageable = PageRequest.of(0, 10);
         Review review = Review.builder().id(1L).book(book).userId(userId).title("R1").content("C1")
-                .createdAt(LocalDateTime.now()).score(5).build();
+                .createdAt(LocalDate.now()).score(5).build();
         Page<Review> page = new PageImpl<>(List.of(review));
 
         given(reviewRepository.findAllByUserId(userId, pageable)).willReturn(page);


### PR DESCRIPTION
## 🔀 PR 개요

기존 ImageMigrationScheduler 실행 시 발생하던 Hibernate Session 동시성 오류(AssertionFailure)를 해결하고, 로드밸런싱 환경(Scale-out)에서 스케줄러 중복 실행을 방지하기 위해 **ShedLock(Redis)**과 TransactionTemplate을 도입했습니다.

---

## 📄 변경 사항

어떤 부분이 수정/추가/삭제되었는지 구체적으로 기술해 주세요.

- [x] 새로운 기능 추가 (✨ Feature)
- [x] 버그 수정 (🐞 BugFix)
- [x] 코드 리팩토링 (🔧 Refactor)
- [ ] 문서 수정 (📝 Docs)
- [ ] 테스트 코드 추가 (🧪 Test)
- [ ] 배포 관련 (🚀 Deploy)
- [ ] 기타 설정 변경 (🧰 Setting)

### ShedLock 도입 (분산 락)

build.gradle: shedlock-spring, shedlock-provider-redis-spring 의존성 추가.

SchedulerLockConfig: Redis를 Lock Provider로 사용하는 설정 클래스 추가.

ImageMigrationScheduler: @SchedulerLock 어노테이션을 적용하여, 다중 서버 환경에서도 지정된 시간 동안 단 하나의 인스턴스만 작업을 수행하도록 보장.

### 트랜잭션 분리 및 스레드 안전성 확보

메인 스레드 트랜잭션 제거: 스케줄러 메서드(migrateImagesChunk)의 @Transactional을 제거하여 불필요한 장기 트랜잭션 및 세션 공유 방지.

ID 기반 처리: 엔티티 객체 자체를 스레드에 넘기지 않고, Book ID 리스트만 추출하여 전달함으로써 영속성 컨텍스트 충돌 원천 차단.

TransactionTemplate 사용: 각 워커 스레드 내부에서 TransactionTemplate을 사용해 개별적인 트랜잭션을 생성하고 findById로 엔티티를 재조회하여 처리.

### 리뷰 등록 / 수정 

### 도서 수정, 삭제 로직 개선


---

## 💡 변경 이유

- Hibernate 동시성 이슈: @Transactional이 걸려있는 메인 스레드의 영속성 컨텍스트(EntityManager)를 비동기 스레드(CompletableFuture)들이 공유하면서 org.hibernate.AssertionFailure: possible non-threadsafe access to the session 에러가 발생함.

- 중복 실행 이슈: 서버를 다중 인스턴스로 띄울 경우, 동일한 스케줄러 작업이 여러 서버에서 동시에 실행되어 이미지 변환 중복 처리 및 리소스 낭비 우려가 있음.

- 도서 수정 및 삭제 안되는 이슈 해결

- 리뷰 등록 및 수정 안되는 이슈 해결


